### PR TITLE
Prompt user to confirm to leave form after update

### DIFF
--- a/projects/file-select/src/lib/file-select.directive.ts
+++ b/projects/file-select/src/lib/file-select.directive.ts
@@ -5,9 +5,9 @@ import { HTMLInputEvent } from './html-input-event.model';
   selector: '[ncatsFileSelect]'
 })
 export class FileSelectDirective implements OnInit, OnDestroy {
-  @Input() accept: string;
+  @Input() accept?: string;
   @Output() selectedFile: EventEmitter<File> = new EventEmitter();
-  private fileInputElement: HTMLInputElement;
+  private fileInputElement?: HTMLInputElement;
 
   constructor(private el: ElementRef) { }
 
@@ -16,7 +16,7 @@ export class FileSelectDirective implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    document.body.removeChild(this.fileInputElement);
+    document.body.removeChild(this.fileInputElement as Node);
   }
 
   addHiddenFileInput() {
@@ -31,7 +31,7 @@ export class FileSelectDirective implements OnInit, OnDestroy {
     }
 
     this.fileInputElement.onchange = (event: HTMLInputEvent) => {
-      if (event.target.files && event.target.files.length > 0) {
+      if (event.target && event.target.files && event.target.files.length > 0) {
         this.selectedFile.emit(event.target.files[event.target.files.length - 1]);
       }
       event.preventDefault();

--- a/src/app/core/app-routing.module.ts
+++ b/src/app/core/app-routing.module.ts
@@ -11,6 +11,7 @@ import { LoginComponent } from './auth/login/login.component';
 import { SubstanceFormComponent } from './substance-form/substance-form.component';
 import { CanActivateSubstanceForm } from './substance-form/can-activate-substance-form';
 import {CanRegisterSubstanceForm} from '@gsrs-core/substance-form/can-register-substance-form';
+import { CanDeactivateSubstanceFormGuard } from './substance-form/can-deactivate-substance-form.guard';
 
 const childRoutes: Routes = [
   {
@@ -28,12 +29,14 @@ const childRoutes: Routes = [
   {
     path: 'substances/register',
     component: SubstanceFormComponent,
-    canActivate: [CanRegisterSubstanceForm]
+    canActivate: [CanRegisterSubstanceForm],
+    canDeactivate: [CanDeactivateSubstanceFormGuard]
   },
   {
     path: 'substances/register/:type',
     component: SubstanceFormComponent,
-    canActivate: [CanRegisterSubstanceForm]
+    canActivate: [CanRegisterSubstanceForm],
+    canDeactivate: [CanDeactivateSubstanceFormGuard]
   },
   {
     path: 'substances/:id',
@@ -58,7 +61,8 @@ const childRoutes: Routes = [
   {
     path: 'substances/:id/edit',
     component: SubstanceFormComponent,
-    canActivate: [CanActivateSubstanceForm]
+    canActivate: [CanActivateSubstanceForm],
+    canDeactivate: [CanDeactivateSubstanceFormGuard]
   }
 ];
 

--- a/src/app/core/substance-form/can-deactivate-substance-form.guard.spec.ts
+++ b/src/app/core/substance-form/can-deactivate-substance-form.guard.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+
+import { CanDeactivateSubstanceFormGuard } from './can-deactivate-substance-form.guard';
+
+describe('CanDeactivateSubstanceFormGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [CanDeactivateSubstanceFormGuard]
+    });
+  });
+
+  it('should ...', inject([CanDeactivateSubstanceFormGuard], (guard: CanDeactivateSubstanceFormGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+});

--- a/src/app/core/substance-form/can-deactivate-substance-form.guard.ts
+++ b/src/app/core/substance-form/can-deactivate-substance-form.guard.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { CanDeactivate } from '@angular/router';
+import { SubstanceFormComponent } from './substance-form.component';
+import { SubstanceFormService } from './substance-form.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CanDeactivateSubstanceFormGuard implements CanDeactivate<SubstanceFormComponent> {
+  constructor(
+    private substanceFormService: SubstanceFormService
+  ) {}
+  canDeactivate(component: SubstanceFormComponent): boolean {
+    if (this.substanceFormService.isSubstanceUpdated) {
+      if (confirm('You have unsaved changes! If you leave, your changes will be lost.')) {
+          return true;
+      } else {
+          return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/app/core/substance-form/can-register-substance-form.ts
+++ b/src/app/core/substance-form/can-register-substance-form.ts
@@ -16,6 +16,7 @@ export class CanRegisterSubstanceForm implements CanActivate {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean> | Promise<boolean> | boolean {
+    console.log('here');
     return new Observable(observer => {
       this.authService.getAuth().subscribe(auth => {
         if (auth) {

--- a/src/app/core/substance-form/substance-form.component.ts
+++ b/src/app/core/substance-form/substance-form.component.ts
@@ -303,4 +303,11 @@ export class SubstanceFormComponent implements OnInit, AfterViewInit, OnDestroy 
       this.submissionMessage = 'Substance is Valid. Would you like to submit?';
     }
   }
+
+  @HostListener('window:beforeunload', ['$event'])
+  unloadNotification($event: any) {
+      if (this.substanceFormService.isSubstanceUpdated) {
+          $event.returnValue = true;
+      }
+  }
 }

--- a/src/app/core/substance-form/substance-form.service.ts
+++ b/src/app/core/substance-form/substance-form.service.ts
@@ -44,6 +44,7 @@ import * as _ from 'lodash';
 })
 export class SubstanceFormService {
   private substance: SubstanceDetail;
+  private substanceStateHash?: number;
   private substanceEmitter = new Subject<SubstanceDetail>();
   private definitionEmitter = new Subject<SubstanceFormDefinition>();
   private substanceReferencesEmitter = new Subject<Array<SubstanceReference>>();
@@ -97,7 +98,6 @@ export class SubstanceFormService {
 
   loadSubstance(substanceClass: string = 'chemical', substance?: SubstanceDetail): void {
     setTimeout(() => {
-
       this.computedMoieties = null;
       this.deletedMoieties = [];
       this.privateDomainsWithReferences = null;
@@ -219,6 +219,8 @@ export class SubstanceFormService {
         });
         }
       }
+      const substanceString = JSON.stringify(this.substance);
+      this.substanceStateHash = this.utilsService.hashCode(substanceString);
     });
   }
 
@@ -357,6 +359,13 @@ unapproveRecord() {
     console.log(e.access);
     alert('Substance definition set to be PUBLIC, please submit to save change');
   }
+
+  get isSubstanceUpdated(): boolean {
+    const substanceString = JSON.stringify(this.substance);
+    console.log(this.substanceStateHash !== this.utilsService.hashCode(substanceString));
+    return this.substanceStateHash !== this.utilsService.hashCode(substanceString);
+  }
+
   // Definition Start
 
   get definition(): Observable<SubstanceFormDefinition> {
@@ -2029,6 +2038,7 @@ unapproveRecord() {
 
         }
         this.substanceChangeReasonEmitter.next(this.substance.changeReason);
+        this.substanceStateHash = this.utilsService.hashCode(this.substance);
         observer.next(results);
         observer.complete();
       }, error => {


### PR DESCRIPTION
1. Added hash of current state of substance when form initially loaded
2. Added listener for `window:beforeunload` event, which calls function that compares current state of substance (converted to a hash), to the hash created when form loaded
3. Added `CanDeactivate` guard that does the same thing as step 2 (necessary for Angular since route change doesn't trigger `beforeunload`)