### PR TITLE
fix copy/paste problem with structures

### DIFF
--- a/src/app/core/substance-form/substance-form.component.ts
+++ b/src/app/core/substance-form/substance-form.component.ts
@@ -348,10 +348,16 @@ export class SubstanceFormComponent implements OnInit, AfterViewInit, OnDestroy 
       const ouuid = uuidHolders[i].uuid;
       if (map[ouuid]) {
         uuidHolders[i].uuid = map[ouuid];
+        if(uuidHolders[i].id){
+             uuidHolders[i].id = map[ouuid];
+        }
       } else {
         const nid = guid();
         uuidHolders[i].uuid = nid;
         map[ouuid] = nid;
+        if(uuidHolders[i].id){
+             uuidHolders[i].id = nid;
+        }
       }
     }
     const refHolders = defiant.json.search(old, '//*[references]');


### PR DESCRIPTION
This should fix the issue with copying a chemical substance definition and attempting to save it (constraint violation). Please confirm.