### PR TITLE
update polymer forms to use idealized structure first

### DIFF
--- a/src/app/core/substance-details/substance-polymer-structure/substance-polymer-structure.component.ts
+++ b/src/app/core/substance-details/substance-polymer-structure/substance-polymer-structure.component.ts
@@ -26,7 +26,7 @@ export class SubstancePolymerStructureComponent extends SubstanceCardBase implem
     this.substanceUpdated.subscribe(substance => {
       this.substance = substance;
       if (this.substance != null) {
-        this.structure = this.substance.polymer.displayStructure;
+        this.structure = this.substance.polymer.idealizedStructure;
         this.classification = this.substance.polymer.classification;
       }
       this.relatedSubstanceUuid = this.classification.parentSubstance && this.classification.parentSubstance.refuuid || '';

--- a/src/app/core/substance-form/substance-form-structure/substance-form-structure.component.ts
+++ b/src/app/core/substance-form/substance-form-structure/substance-form-structure.component.ts
@@ -37,13 +37,16 @@ export class SubstanceFormStructureComponent extends SubstanceFormBase implement
       this.substanceType = def.substanceClass;
       if (this.substanceType === 'polymer') {
         this.menuLabelUpdate.emit('Idealized Structure');
-        this.substanceFormService.substanceDisplayStructure.subscribe(structure => {
+        this.substanceFormService.substanceIdealizedStructure.subscribe(structure => {
           if (structure) {
             this.structure = structure;
           } else {
-            this.substanceFormService.substanceIdealizedStructure.subscribe(structure2 => {
-              this.structure = structure2;
-            });
+	   // while we also want to do something with display structures eventually,
+           // this isn't the place to do it, I don't think ...
+           //
+           // this.substanceFormService.substanceDisplayStructure.subscribe(structure2 => {
+           //   this.structure = structure2;
+           // });
           }
           this.loadStructure();
         });


### PR DESCRIPTION
This makes the polymer editor use only the idealized structure rather than the display structure too. The incompatibility between the two caused issues before.