### PR TITLE
alternative fix for primary substances

### DIFF
--- a/src/app/core/substance-form/substance-form-codes/substance-form-codes.component.html
+++ b/src/app/core/substance-form/substance-form-codes/substance-form-codes.component.html
@@ -3,7 +3,7 @@
     <input matInput placeholder="Search" [formControl]="searchControl">
   </mat-form-field>
   <span class="middle-fill"></span>
-  <button mat-button (click)="addCode()">
+  <button mat-button (click)="addCode()" [disabled] = "isAlternative">
     Add code <mat-icon svgIcon="add_circle_outline"></mat-icon>
   </button>
 </div>

--- a/src/app/core/substance-form/substance-form-codes/substance-form-codes.component.ts
+++ b/src/app/core/substance-form/substance-form-codes/substance-form-codes.component.ts
@@ -14,6 +14,7 @@ import { Subscription } from 'rxjs';
 export class SubstanceFormCodesComponent extends SubstanceCardBaseFilteredList<SubstanceCode> implements OnInit, AfterViewInit, OnDestroy {
   codes: Array<SubstanceCode>;
   private subscriptions: Array<Subscription> = [];
+  isAlternative = false;
 
   constructor(
     private substanceFormService: SubstanceFormService,
@@ -29,6 +30,14 @@ export class SubstanceFormCodesComponent extends SubstanceCardBaseFilteredList<S
   }
 
   ngAfterViewInit() {
+    const definitionSubscription = this.substanceFormService.definition.subscribe( level => {
+      if (level.definitionType && level.definitionType === 'ALTERNATIVE') {
+        this.isAlternative = true;
+      } else {
+        this.isAlternative = false;
+      }
+    });
+    this.subscriptions.push(definitionSubscription);
     const codesSubscription = this.substanceFormService.substanceCodes.subscribe(codes => {
       this.codes = codes;
       this.filtered = codes;

--- a/src/app/core/substance-form/substance-form-names/substance-form-names.component.html
+++ b/src/app/core/substance-form/substance-form-names/substance-form-names.component.html
@@ -5,7 +5,7 @@
   <span class="middle-fill"></span>
   <button *ngIf="names && names.length > 0" class = 'standardize' mat-button (click)="standardize()">Standardize Names</button>
 
-  <button mat-button (click)="addName()">
+  <button mat-button (click)="addName()" [disabled] = "isAlternative">
     Add name <mat-icon svgIcon="add_circle_outline"></mat-icon>
   </button>
 

--- a/src/app/core/substance-form/substance-form-names/substance-form-names.component.ts
+++ b/src/app/core/substance-form/substance-form-names/substance-form-names.component.ts
@@ -14,6 +14,7 @@ import { Subscription } from 'rxjs';
 export class SubstanceFormNamesComponent extends SubstanceCardBaseFilteredList<SubstanceName> implements OnInit, AfterViewInit, OnDestroy {
   names: Array<SubstanceName>;
   private subscriptions: Array<Subscription> = [];
+  isAlternative = false;
 
   constructor(
     private substanceFormService: SubstanceFormService,
@@ -29,6 +30,14 @@ export class SubstanceFormNamesComponent extends SubstanceCardBaseFilteredList<S
   }
 
   ngAfterViewInit() {
+    const definitionSubscription = this.substanceFormService.definition.subscribe( level => {
+      if (level.definitionType && level.definitionType === 'ALTERNATIVE') {
+        this.isAlternative = true;
+      } else {
+        this.isAlternative = false;
+      }
+      });
+    this.subscriptions.push(definitionSubscription);
     const namesSubscription = this.substanceFormService.substanceNames.subscribe(names => {
       this.names = names;
       this.filtered = names;

--- a/src/app/core/substance-form/substance-form.service.ts
+++ b/src/app/core/substance-form/substance-form.service.ts
@@ -374,14 +374,13 @@ unapproveRecord() {
         observer.next(this.getDefinition());
         // tslint:disable-next-line:no-shadowed-variable
         this.definitionEmitter.subscribe(definition => {
-          observer.next(this.getDefinition());
+          observer.next(definition);
         });
       });
     });
   }
 
   updateDefinition(definition: SubstanceFormDefinition): void {
-    this.substance.definitionType = definition.definitionType;
     this.substance.definitionLevel = definition.definitionLevel;
     this.substance.deprecated = definition.deprecated;
     this.substance.access = definition.access;
@@ -399,6 +398,18 @@ unapproveRecord() {
         references: definition.references
       };
     }
+
+    if (this.substance.definitionType !== definition.definitionType) {
+      if ( definition.definitionType === 'ALTERNATIVE') {
+        this.substance.names = [];
+        this.substance.codes = [];
+        this.substanceNamesEmitter.next(this.substance.names);
+        this.substanceCodesEmitter.next(this.substance.codes);
+
+      }
+    }
+    this.substance.definitionType = definition.definitionType;
+    this.definitionEmitter.next(this.getDefinition());
   }
 
   getJson() {


### PR DESCRIPTION
Alternative substances cannot have names or codes. Since we can't un-load those cards, this will subscribe them to the definition type, which if alternative, removes those property values and prevents new entries being added, so the substance can still be validated. Deletion of property values matches old site functionality