### PR TITLE
fix for net charge update

### DIFF
--- a/src/app/core/substance-form/substance-form-structure/substance-form-structure.component.ts
+++ b/src/app/core/substance-form/substance-form-structure/substance-form-structure.component.ts
@@ -137,7 +137,7 @@ export class SubstanceFormStructureComponent extends SubstanceFormBase implement
     if (structurePostResponse && structurePostResponse.structure) {
 
       // we should only be dealing with this stuff if the total hash changes
-      if (this.structure['hash'] !== structurePostResponse.structure['hash']) {
+      if (this.structure['hash'] !== structurePostResponse.structure['hash'] || this.structure['charge'] !== structurePostResponse.structure['charge']) {
          this.smiles = structurePostResponse.structure.smiles;
          this.mol = structurePostResponse.structure.molfile;
 


### PR DESCRIPTION
https://cnigsllc.atlassian.net/browse/GSRS-1385

When modifiying a chemical structure, the moieties and net charge don't get updated if you change the charge of an atom in-place. This is untested, but should fix this issue.