### PR TITLE
allow aesthetic updates to save on structure

### DIFF
--- a/src/app/core/substance-form/structure/substance-form-structure-card.component.ts
+++ b/src/app/core/substance-form/structure/substance-form-structure-card.component.ts
@@ -56,7 +56,6 @@ export class SubstanceFormStructureCardComponent extends SubstanceFormBase imple
       if (this.substanceType === 'polymer') {
         this.menuLabelUpdate.emit('Idealized Structure');
         const idealStructSubscription = this.substanceFormStructureService.substanceIdealizedStructure.subscribe(structure => {
-          console.log(structure);
           if (structure) {
             this.structure = structure;
           } else {
@@ -135,6 +134,7 @@ export class SubstanceFormStructureCardComponent extends SubstanceFormBase imple
 
   updateStructureForm(molfile: string): void {
     if (!this.isInitializing) {
+      this.structure.molfile = molfile;
       this.structureService.interpretStructure(molfile).subscribe(response => {
         this.processStructurePostResponse(response);
       });
@@ -154,7 +154,10 @@ export class SubstanceFormStructureCardComponent extends SubstanceFormBase imple
 
          // this is sometimes overly ambitious
          Object.keys(structurePostResponse.structure).forEach(key => {
-           this.structure[key] = structurePostResponse.structure[key];
+           //we don't want to do this with molfile, we want to trust the editor
+           if(key!=="molfile"){
+              this.structure[key] = structurePostResponse.structure[key];
+           }
          });
 
          this.structure.uuid = '';


### PR DESCRIPTION
https://cnigsllc.atlassian.net/projects/GSRS/issues/GSRS-1472

The current way the form works is that a structure is drawn, the molfile is sent to the server, and then the calculated properties of the structure as JSON seed the structure form elements. Every change makes the same round-trip happen. There were issues with doing things this way. For one, the interpretation by the server isn't always exactly in line with how the editor draw the structure, and minor formatting issues in a molfile would get clobbered by the round-trip.

In addition, changes to stereochemistry and other fields get clobbered with every minor change to the structure since they force another round-trip. To fix this, we had previously restricted the round-trip interpretation to only clobber on a definitional change. However, this had the unfortunate side effect that any purely aesthetic change to the structure didn't get saved since the round-trip wasn't honored and therefore the structure wasn't updated.

This fix does 2 things:
1. It allows updates the the molfile property to not need the roundtrip from the server, but gets them from the editor directly.
2. It does not accept updates to the molfile property from the server.

These two fixes should theoretically allow aesthetic changes to be saved.