### PR TITLE
Hide full fields if part with dev stage

### DIFF
--- a/src/app/core/substance-form/structurally-diverse/substance-form-structurally-diverse-source/substance-form-structurally-diverse-source.component.ts
+++ b/src/app/core/substance-form/structurally-diverse/substance-form-structurally-diverse-source/substance-form-structurally-diverse-source.component.ts
@@ -93,7 +93,7 @@ export class SubstanceFormStructurallyDiverseSourceComponent  extends SubstanceF
 
   checkWhole(): boolean {
     const check = ['organismFamily', 'organismGenus', 'organismSpecies', 'organismAuthor', 'infraSpecificType', 'infraSpecificName',
-     'hybridSpeciesMaternalOrganism', 'hybridSpeciesPaternalOrganism', 'developmentalStage'];
+     'hybridSpeciesMaternalOrganism', 'hybridSpeciesPaternalOrganism'];
     let found = true;
     check.forEach( field => {
       if (this.structurallyDiverse[field] && this.structurallyDiverse[field] !== null &&


### PR DESCRIPTION
DevelopmentalStage is a field that shows up in both forms. Shouldn't show "full fields" based on its population alone.