### PR TITLE
allow fix for unexpected error syntax

### DIFF
--- a/src/app/core/substance-form/definition-switch-dialog/definition-switch-dialog.component.ts
+++ b/src/app/core/substance-form/definition-switch-dialog/definition-switch-dialog.component.ts
@@ -414,7 +414,7 @@ export class DefinitionSwitchDialogComponent implements OnInit {
             console.log('SENT SUBSTANCE');
             console.log(nsub);
             let errorString = 'VALIDATION ERROR - \n\n';
-            if (error && error.error) {
+            if (error && error.error && error.error.validationMessages) {
               error.error.validationMessages.forEach( e => {
                 if (e.messageType === 'ERROR') {
                   errorString += e.message + '\n\n';
@@ -422,6 +422,8 @@ export class DefinitionSwitchDialogComponent implements OnInit {
               });
             } else if (error && error.message) {
               errorString += error.message;
+            } else {
+              errorString += "unknown server error";
             }
             this.error = errorString;
             this.undo(step);


### PR DESCRIPTION
This is surprising to me, but sometimes the error response from the server is in a format unexpected by this code and results in catastrophic failure:
![image](https://user-images.githubusercontent.com/1581898/134986137-1aa2de68-71d5-4e13-bfae-285ba49dc28a.png)

The changes made here should protect against that.