### PR TITLE
We should show the date the user profile was last edited, not user

### DIFF
--- a/src/app/core/admin/user-management/user-management.component.html
+++ b/src/app/core/admin/user-management/user-management.component.html
@@ -51,7 +51,7 @@
       </ng-container>
       <ng-container matColumnDef="modified">
         <th mat-header-cell *matHeaderCellDef mat-sort-header> Modified</th>
-        <td mat-cell *matCellDef="let user"> {{user.user.modified | date:'medium'}} </td>
+        <td mat-cell *matCellDef="let user"> {{user.modified | date:'medium'}} </td>
       </ng-container>
       <ng-container matColumnDef="active">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Active/ Set Inactive</th>


### PR DESCRIPTION
When an admin changes a user's roles, groups, password, active status, etc, they're updating the UserProfile (user). When they change the username or email, they're changing the Principal (user.user). We show the modified/create dates for the Principal now, but that will make it look like users weren't modified even though they often were.

Having the _create_ date be based on the underlying principal is fine. But the modified date to show the admin user is for the parent UserProfile, since it will show a more granular update.