### PR TITLE
Hide/show some icons based on different roles

### DIFF
--- a/src/app/core/substances-browse/substance-summary-card/substance-summary-card.component.html
+++ b/src/app/core/substances-browse/substance-summary-card/substance-summary-card.component.html
@@ -63,7 +63,7 @@
           <mat-icon svgIcon="edit"></mat-icon>
         </a>
 
-        <button class = "summary-button" *ngIf="isAdmin" mat-icon-button [matMenuTriggerFor]="editMenu">
+        <button class = "summary-button" *ngIf="canCreate" mat-icon-button [matMenuTriggerFor]="editMenu">
           <mat-icon svgIcon="file_copy"></mat-icon>
         </button>
 

--- a/src/app/core/substances-browse/substance-summary-card/substance-summary-card.component.ts
+++ b/src/app/core/substances-browse/substance-summary-card/substance-summary-card.component.ts
@@ -33,7 +33,8 @@ export class SubstanceSummaryCardComponent implements OnInit {
   private privateSubstance: SubstanceSummary;
   @Output() openImage = new EventEmitter<SubstanceSummary>();
   @Input() showAudit: boolean;
-  isAdmin = false;
+  isAdmin = false;  //this shouldn't be called "isAdmin", it's typically used to mean "canUpdate". Should fix for future devs.
+  canCreate = false; //meant to allow creating new records
   subunits?: Array<Subunit>;
   @ViewChild(CardDynamicSectionDirective, {static: true}) dynamicContentContainer: CardDynamicSectionDirective;
   @Input() names?: Array<SubstanceName>;
@@ -62,9 +63,14 @@ export class SubstanceSummaryCardComponent implements OnInit {
   ngOnInit() {
     this.overlayContainer = this.overlayContainerService.getContainerElement();
 
-    this.authService.hasAnyRolesAsync('Updater', 'SuperUpdater').pipe(take(1)).subscribe(response => {
+    this.authService.hasAnyRolesAsync('Updater', 'SuperUpdater', 'Approver', 'admin').pipe(take(1)).subscribe(response => {
       if (response) {
         this.isAdmin = response;
+      }
+    });
+    this.authService.hasAnyRolesAsync('DataEntry', 'SuperDataEntry', 'admin').pipe(take(1)).subscribe(response => {
+      if (response) {
+        this.canCreate = response;
       }
     });
     if (this.substance.protein) {


### PR DESCRIPTION
Not only Updater and SuperUpdater can do changes to a record. Admins and approvers can too (though they do different things).

Also, adding a flag to only allow copying records for data entry users.