### PR TITLE
The way the base API url works has changed

### DIFF
--- a/src/app/fda/application/service/application.service.ts
+++ b/src/app/fda/application/service/application.service.ts
@@ -27,9 +27,10 @@ export class ApplicationService extends BaseHttpService {
   totalRecords = 0;
   application: Application;
 
-  apiBaseUrlWithApplicationEntityUrl = this.apiBaseUrl + 'applications' + '/';
-  apiBaseUrlWithApplicationAllEntityUrl = this.apiBaseUrl + 'applicationsall' + '/';
-  apiBaseUrlWithApplicationDarrtsEntityUrl = this.apiBaseUrl + 'applicationsdarrts' + '/';
+  apiBaseUrlWithApplicationEntityUrl =       this.configService.configData.apiBaseUrl + 'api/v1/applications' + '/';
+  apiBaseUrlWithApplicationAllEntityUrl =    this.configService.configData.apiBaseUrl + 'api/v1/applicationsall' + '/';
+//TODO: remove explicit references like this if at all possible
+  apiBaseUrlWithApplicationDarrtsEntityUrl = this.configService.configData.apiBaseUrl + 'api/v1/applicationsdarrts' + '/';
 
   constructor(
     public http: HttpClient,


### PR DESCRIPTION
The APIBaseURL settings for the codebase are probably the most confusing part of the code. Niko and I took some time to try to make a plan to make this easier, but I think it hasn't paid off in the ways we'd hoped. Instead, the codebase is still pretty confused/confusing about what an apiBaseURL is, when it's set, how it's set, how it relates to the config file, etc.

Somewhere in the shuffle, I believe the way that things are loaded changed, so some of the mechanisms being used no longer work. I think this will fix how the search within facets setting works, but I'm not entirely sure. @narchana will have to see.