### PR TITLE
Update JSDraw.extensions.js

### DIFF
--- a/src/app/core/assets/jsdraw/JSDraw.extensions.js
+++ b/src/app/core/assets/jsdraw/JSDraw.extensions.js
@@ -907,4 +907,9 @@ var callback = function(){
         //pubchem
         document.querySelectorAll("[cmd=pubchem]")[0].closest("td").nextElementSibling.remove();
         document.querySelectorAll("[cmd=pubchem]")[0].closest("td").remove();
+     
+        // This prevents atom list dialog from being tied to an old now deactivated form:
+        // Note that this is still an issue if there is more than one editor being used at one
+        // time. JSDraw will need to fix.
+        JSDraw2.Editor.atomlistDlg=null;
     }


### PR DESCRIPTION
Small change to fix the issue with JSDraw not supporting query atom lists if at least one other instance of the editor has been used to enter atom lists at least once in the past before a refresh.