### PR TITLE
Fix the regex for cleaning up meta-references

### DIFF
--- a/src/app/core/substance-form/substance-form.service.ts
+++ b/src/app/core/substance-form/substance-form.service.ts
@@ -1368,7 +1368,7 @@ this.emitDisulfideLinkUpdate();
       deletedUuids.forEach(uuid => {
         substanceString = substanceString.replace(new RegExp(`"${uuid}"`, 'g'), '');
       });
-      substanceString = substanceString.replace(/,,/g, ',');
+      substanceString = substanceString.replace(/,[,]+/g, ',');
       substanceString = substanceString.replace(/\[,/g, '[');
       substanceString = substanceString.replace(/,\]/g, ']');
       substanceCopy = JSON.parse(substanceString);


### PR DESCRIPTION
In certain cases, trying to remove 2 or more references at the same time, when they're mentioned in the middle of a name/code/etc set of references, the result can not remove _triple_ commas correctly. This replaces all rogue multiple commas.

Note: this is a little strange in general, as it could end up replacing multiple commas inside the actual JSON context strings. That should be very rare, but there could be cases where it's an issue. 