### PR TITLE
WIP: front associate labels with match types

### DIFF
--- a/src/app/core/substances-browse/substances-browse.component.html
+++ b/src/app/core/substances-browse/substances-browse.component.html
@@ -40,9 +40,13 @@
           <mat-menu class="search-suggestions-container" #searchSuggestions="matMenu">
             <div *ngFor="let matchType of sortMatchTypes(matchTypes)">
               <div class="match-type" [ngSwitch]="matchType">
-                <div *ngSwitchCase="'WORD'">Contains Match</div>
                 <div *ngSwitchCase="'ADDITIONAL'">Other Match</div>
-                <div *ngSwitchDefault>Exact Match</div>
+                <div *ngSwitchCase="'FULL'">Exact Match</div>
+                <div *ngSwitchCase="'CONTAINS'">Contains Match</div>
+                <div *ngSwitchCase="'WORD'">Contains Match</div>
+                <div *ngSwitchCase="'WORD_STARTS_WITH'">Contains Match</div>
+                <div *ngSwitchCase="'NO_MATCH'">No Match</div>
+                <div *ngSwitchDefault>Unknown Match</div>
               </div>
               <button mat-menu-item *ngFor="let suggestion of narrowSearchSuggestions[matchType]"
                 (click)="restricSearh(suggestion.luceneQuery)">

--- a/src/app/core/substances-browse/substances-browse.component.ts
+++ b/src/app/core/substances-browse/substances-browse.component.ts
@@ -499,7 +499,7 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
                 luceneQuery: lq
               };
               this.substanceService.searchSubstances(lq).subscribe(response => {
-                if(response && response.total>0) {
+                if(response?.total && response.total>0) {
                   suggestion.count = response.total;
                   if (this.narrowSearchSuggestions[suggestion.matchType] == null) {
                     this.narrowSearchSuggestions[suggestion.matchType] = [];

--- a/src/app/core/substances-browse/substances-browse.component.ts
+++ b/src/app/core/substances-browse/substances-browse.component.ts
@@ -499,7 +499,7 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
                 luceneQuery: lq
               };
               this.substanceService.searchSubstances(lq).subscribe(response => {
-                if(response && response.total!==null) {
+                if(response && response.total>0) {
                   suggestion.count = response.total;
                   if (this.narrowSearchSuggestions[suggestion.matchType] == null) {
                     this.narrowSearchSuggestions[suggestion.matchType] = [];


### PR DESCRIPTION
Contains matches were being labeled as exact matches.  this creates a switch with all backend match types plus the additional ui created match type.   Most match types will fall under "Contains Match" 

Also creates condition so that begins with match won't appear if the # found is not > 0.