### PR TITLE
Prevent double context menus on jsdraw right-click

### DIFF
--- a/src/app/core/assets/jsdraw/JSDraw.extensions.js
+++ b/src/app/core/assets/jsdraw/JSDraw.extensions.js
@@ -912,4 +912,28 @@ var callback = function(){
         // Note that this is still an issue if there is more than one editor being used at one
         // time. JSDraw will need to fix.
         JSDraw2.Editor.atomlistDlg=null;
+        
+        // This prevents the context menu from spawning more events on right-click events
+        (function() {
+            var contextMenuChecker = (e) => {
+                if (e.path) {
+                    for (var i = 0; i < e.path.length; i++) {
+                        var elm = e.path[i];
+                        var checkElm = elm;
+                        if (i === 0 && elm.tagName === "TABLE" && e.path[i + 1].tagName === "BODY" && elm.chlidren.length > 0) {
+                            checkElm = elm.children[0];
+                        }
+                        if (checkElm.getAttribute && checkElm.getAttribute("jspopupmenu")) {
+                            e.preventDefault();
+                            return false;
+                        }
+                    }
+                }
+            };
+            if (document.addEventListener) {
+                document.addEventListener('contextmenu', contextMenuChecker, false);
+            } else {
+                document.attachEvent('oncontextmenu', contextMenuChecker);
+            }
+        }());
     }


### PR DESCRIPTION
This prevents double context menus on JSDraw right clicks which appear to happen in modern chrome+firefox browsers on windows OS (but likely not on linux/macOS).

**The problem:**
right clicking on the _white part_ of a structure editor widget causes 2 menus to appear. 1 is the system menu and one is the JSDraw menu.
![image](https://user-images.githubusercontent.com/1581898/181301961-ab9f81bd-1263-4b8f-94f3-f9d6d901b1e8.png)


**The cause:**
This appears to happen because JSDraw injects a new HTML element to the body of the DOM, and that element is a table. That TABLE element somehow triggers a right-click mouse event (which also triggers a context menu event). While there are things in place to prevent the main JSDraw HTML element itself from triggering a system-level context menu, there's nothing in place to prevent the injected menu from triggering this event. A recent change to chrome/firefox seems to have allowed this event pipeline to propagate differently than it used to, so the existing preventing methods inherent to JSDraw fail.

**The solution:**
GSRS loads JSDraw with some extra javascript to enable/disable certain JSDraw features, change some of its default behavior, and prevent some particular bugs that happen with the JSDraw integration. Adding a special context menu listener to the DOM document at that stage within that special javascript allows us to have JSDraw-specific bug fixes localized to JSDraw-specific files. The code itself checks if a context menu event was triggered from an HTML "table" element which is a child of "body", and which has a child with the "jsdrawmenu" attribute used by jsdraw to mark its context menu. If that table element or the "jsdrawmenu" element itself is found in the triggering element path, the event is triggered to have default prevented.