### PR TITLE
fix popup to use substance id

### DIFF
--- a/src/app/core/substances-browse/substances-browse.component.ts
+++ b/src/app/core/substances-browse/substances-browse.component.ts
@@ -932,17 +932,19 @@ searchTermOkforBeginsWithSearch(): boolean {
 
     if (substance.substanceClass === 'chemical') {
       data = {
-        structure: substance.structure.id,
+        structure: substance.uuid,
         smiles: substance.structure.smiles,
         uuid: substance.uuid,
         names: this.names[substance.uuid]
       };
     } else {
       data = {
-        structure: substance.polymer.displayStructure.id,
+        structure: substance.uuid,
         names: this.names[substance.uuid]
       };
     }
+
+    
 
     const dialogRef = this.dialog.open(StructureImageModalComponent, {
       width: '650px',


### PR DESCRIPTION
Currently the zoom-in popup for structures on browse uses the structure or displayStructure id for the structure to zoom in on. It can and should use the substance ID instead.