### PR TITLE
Substructure Async Search Browse Results Fixes

### DIFF
--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -53,6 +53,19 @@ export class AuthInterceptor implements HttpInterceptor {
                     });
                 }
 
+               req = req.clone({
+                    headers: req.headers.set('auth-password', 'admin')
+                });
+                req = req.clone({
+                    headers: req.headers.set('auth-username', 'PondPine75')
+                });
+              /*  req = req.clone({
+                    headers: req.headers.set('auth-password', 'admin')
+                });
+                req = req.clone({
+                    headers: req.headers.set('auth-username', 'admin')
+                });*/
+
             } catch (e) {
                 console.log('ERROR in intercept function: ' + e);
             }

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -52,20 +52,6 @@ export class AuthInterceptor implements HttpInterceptor {
                         headers: req.headers.set('auth-token', authToken)
                     });
                 }
-
-               req = req.clone({
-                    headers: req.headers.set('auth-password', 'admin')
-                });
-                req = req.clone({
-                    headers: req.headers.set('auth-username', 'PondPine75')
-                });
-              /*  req = req.clone({
-                    headers: req.headers.set('auth-password', 'admin')
-                });
-                req = req.clone({
-                    headers: req.headers.set('auth-username', 'admin')
-                });*/
-
             } catch (e) {
                 console.log('ERROR in intercept function: ' + e);
             }

--- a/src/app/core/structure/structure-image-modal/structure-image-modal.component.ts
+++ b/src/app/core/structure/structure-image-modal/structure-image-modal.component.ts
@@ -98,8 +98,8 @@ export class StructureImageModalComponent implements OnInit {
     if (this.configService.configData && this.configService.configData.gsrsHomeBaseUrl) {
       url = this.configService.configData.gsrsHomeBaseUrl + '/substances/' + this.uuid;
       
-    } else {
-      url = this.router.serializeUrl(
+    } else {const baseUrl = window.location.href.replace(this.router.url, '');
+      url = baseUrl + this.router.serializeUrl(
         this.router.createUrlTree(['/substances/' + this.uuid])
       );
     }
@@ -113,7 +113,8 @@ export class StructureImageModalComponent implements OnInit {
       url = this.configService.configData.gsrsHomeBaseUrl + '/substances/' + this.uuid + '/edit';
       
     } else {
-      url = this.router.serializeUrl(
+      const baseUrl = window.location.href.replace(this.router.url, '');
+     url = baseUrl + this.router.serializeUrl(
         this.router.createUrlTree(['/substances/' + this.uuid + '/edit'])
       );
     }

--- a/src/app/core/substance-form/substance-form.component.html
+++ b/src/app/core/substance-form/substance-form.component.html
@@ -139,8 +139,8 @@
       </div>
       <span class="middle-fill"></span>
       <button mat-flat-button color="primary" class="validate-button" (click)="validate()">Validate for Submission</button>
-      <button mat-flat-button color="primary" class="validate-button" [disabled]=" approving"
-              *ngIf="definition && definition.substanceClass!=='concept' && !definition.approvalID && !imported && definitionType !== 'ALTERNATIVE'"
+      <button mat-flat-button color="primary" class="validate-button" [disabled]="!canApprove || approving"
+                    *ngIf="definition && definition.substanceClass!=='concept' && !definition.approvalID && !imported && definitionType !== 'ALTERNATIVE'"
               (click)="validate('approval')">Approve
       </button>
 
@@ -219,8 +219,8 @@
           Cancel
         </button>
         <button mat-flat-button color="primary" *ngIf="approving" (click)="approve()"
-                [disabled]="isLoading" > Confirm Approval
-        </button>
+        [disabled]="isLoading || !canApprove"> Confirm Approval
+              </button>
 
       </div>
     </div>

--- a/src/app/core/substance-form/substance-form.component.html
+++ b/src/app/core/substance-form/substance-form.component.html
@@ -139,7 +139,7 @@
       </div>
       <span class="middle-fill"></span>
       <button mat-flat-button color="primary" class="validate-button" (click)="validate()">Validate for Submission</button>
-      <button mat-flat-button color="primary" class="validate-button" [disabled]="!canApprove || approving"
+      <button mat-flat-button color="primary" class="validate-button" [disabled]=" approving"
               *ngIf="definition && definition.substanceClass!=='concept' && !definition.approvalID && !imported && definitionType !== 'ALTERNATIVE'"
               (click)="validate('approval')">Approve
       </button>
@@ -219,7 +219,7 @@
           Cancel
         </button>
         <button mat-flat-button color="primary" *ngIf="approving" (click)="approve()"
-                [disabled]="isLoading || !canApprove"> Confirm Approval
+                [disabled]="isLoading" > Confirm Approval
         </button>
 
       </div>

--- a/src/app/core/substance-selector/advanced-selector-dialog/advanced-selector-dialog.component.ts
+++ b/src/app/core/substance-selector/advanced-selector-dialog/advanced-selector-dialog.component.ts
@@ -111,7 +111,9 @@ private privateSequenceSearchKey?: string;
     if (this.configService.configData && this.configService.configData.gsrsHomeBaseUrl) {
       url = this.configService.configData.gsrsHomeBaseUrl + '/substances/register/chemical' + '?importStructure=' + encodeURIComponent(smiles);
     } else {
-      url = this.router.serializeUrl(
+      
+      const baseUrl = window.location.href.replace(this.router.url, '');
+      url = baseUrl + this.router.serializeUrl(
         this.router.createUrlTree(['/substances/register/chemical'], {
           queryParams: navigationExtras.queryParams})
       );

--- a/src/app/core/substance-selector/substance-selector.component.ts
+++ b/src/app/core/substance-selector/substance-selector.component.ts
@@ -234,7 +234,8 @@ export class SubstanceSelectorComponent implements OnInit {
       url = this.configService.configData.gsrsHomeBaseUrl + '/substances/register';
       
     } else {
-      url = this.router.serializeUrl(
+      const baseUrl = window.location.href.replace(this.router.url, '');
+      url = baseUrl + this.router.serializeUrl(
         this.router.createUrlTree(['/substances/register'])
       );
     }

--- a/src/app/core/substance-selector/substance-selector.component.ts
+++ b/src/app/core/substance-selector/substance-selector.component.ts
@@ -221,8 +221,8 @@ export class SubstanceSelectorComponent implements OnInit {
       url = this.configService.configData.gsrsHomeBaseUrl + '/substances/' + uuid;
       
     } else {
-      url = this.router.serializeUrl(
-        this.router.createUrlTree(['/substances/' + uuid])
+      const baseUrl = window.location.href.replace(this.router.url, '');
+      url = baseUrl + this.router.serializeUrl(this.router.createUrlTree(['/substances/' + uuid])
       );
     }
     window.open(url, '_blank');

--- a/src/app/core/substance/substance.service.ts
+++ b/src/app/core/substance/substance.service.ts
@@ -239,6 +239,7 @@ export class SubstanceService extends BaseHttpService {
         sync = true;
       }
       if (!sync && this.searchKeys[structureFacetsKey]) {
+        console.log('not sync');
         url += `status(${this.searchKeys[structureFacetsKey]})/results`;
         params = params.appendFacetParams(facets, this.showDeprecated);
         if(querySearchTerm.length > 0) {
@@ -256,8 +257,12 @@ export class SubstanceService extends BaseHttpService {
         if (order != null && order !== '') {
           params = params.append('order', order);
         }
+        console.log(url);
+        console.log(params);
 
       } else {
+        console.log(sync);
+        console.log(type);
         params = params.append('q', (searchTerm));
         if (type) {
           params = params.append('type', type);
@@ -282,6 +287,7 @@ export class SubstanceService extends BaseHttpService {
           }
         }
         url += 'substances/structureSearch';
+        console.log(url);
       }
 
       const options = {
@@ -290,8 +296,10 @@ export class SubstanceService extends BaseHttpService {
 
       this.http.get<any>(url, options).subscribe(
         response => {
+          console.log(response);
           // call async
           if (response.results) {
+            console.log('call async');
             const resultKey = response.key;
             this.searchKeys[structureFacetsKey] = resultKey;
             this.processAsyncSearchResults(
@@ -306,6 +314,7 @@ export class SubstanceService extends BaseHttpService {
               skip
             );
           } else {
+            console.log('complete');
             observer.next(response);
             observer.complete();
           }
@@ -451,6 +460,8 @@ export class SubstanceService extends BaseHttpService {
         response => {
           // call async
           if (response.results) {
+            console.log('has results');
+            console.log(response);
             const resultKey = response.key;
             this.searchKeys[bulkFacetsKey] = resultKey;
             this.processAsyncSearchResults(
@@ -466,6 +477,7 @@ export class SubstanceService extends BaseHttpService {
             );
           } else {
             // consider making API backend provide statusKey in JSON
+            console.log('not results)');
             if(this.searchKeys && this.searchKeys[bulkFacetsKey]) {
               response.statusKey = this.searchKeys[bulkFacetsKey];
             }
@@ -492,6 +504,7 @@ export class SubstanceService extends BaseHttpService {
     skip?: number,
     view?: string
   ): void {
+    console.log(asyncCallResponse);
     this.getAsyncSearchResults(
       querySearchTerm,
       searchKey,
@@ -503,8 +516,10 @@ export class SubstanceService extends BaseHttpService {
       .subscribe(response => {
         // consider making API backend provide statusKey in JSON
         response.statusKey=searchKey;
+        response.finished = asyncCallResponse.finished;
         observer.next(response);
         if (!asyncCallResponse.finished) {
+          console.log('not finished');
           this.http.get<any>(url, httpCallOptions).subscribe(searchResponse => {
 
             setTimeout(() => {

--- a/src/app/core/substance/substance.service.ts
+++ b/src/app/core/substance/substance.service.ts
@@ -95,6 +95,9 @@ export class SubstanceService extends BaseHttpService {
       this.tempObject.view);
   }
 
+  unpauseAsyncSubject() {
+    this.pauseSubject.next(false);
+  }
 
   setResult(result: string, content: Array<any>, total: number) {
     const uuid = [];
@@ -568,7 +571,11 @@ export class SubstanceService extends BaseHttpService {
       );
   }
 
-
+  clearSearchKey() {
+    Object.keys(this.searchKeys).forEach(key => {
+      this.searchKeys[key] = undefined;
+    });
+  }
 
   private getAsyncSearchResults(
     querySearchTerm: string,

--- a/src/app/core/substance/substance.service.ts
+++ b/src/app/core/substance/substance.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams, HttpClientJsonpModule, HttpParameterCodec } from '@angular/common/http';
-import { interval, Observable, Observer, Subject } from 'rxjs';
+import { BehaviorSubject, interval, Observable, Observer, Subject } from 'rxjs';
 import { ConfigService } from '../config/config.service';
 import { BaseHttpService } from '../base/base-http.service';
 import {
@@ -53,6 +53,8 @@ export class SubstanceService extends BaseHttpService {
   showImagePopup = new Subject<boolean>();
   imagePopupUnit = new Subject<StructuralUnit>();
   private searchResult: any;
+  private pauseSubject = new BehaviorSubject<boolean>(false);
+  tempObject: any;
   constructor(
     public http: HttpClient,
     public configService: ConfigService,
@@ -73,6 +75,26 @@ export class SubstanceService extends BaseHttpService {
       });
     });
   }
+
+  pauseAsyncSearch() {
+    this.pauseSubject.next(true);
+  }
+
+  resumeAsyncSearch() {
+    this.pauseSubject.next(false);
+    this.processAsyncSearchResults(
+      this.tempObject.querySearchTerm,
+      this.tempObject.url,
+      this.tempObject.asyncCallResponse,
+      this.tempObject.observer,
+      this.tempObject.searchKey,
+      this.tempObject.httpCallOptions,
+      this.tempObject.pageSize,
+      this.tempObject.facets,
+      this.tempObject.skip,
+      this.tempObject.view);
+  }
+
 
   setResult(result: string, content: Array<any>, total: number) {
     const uuid = [];
@@ -239,7 +261,6 @@ export class SubstanceService extends BaseHttpService {
         sync = true;
       }
       if (!sync && this.searchKeys[structureFacetsKey]) {
-        console.log('not sync');
         url += `status(${this.searchKeys[structureFacetsKey]})/results`;
         params = params.appendFacetParams(facets, this.showDeprecated);
         if(querySearchTerm.length > 0) {
@@ -257,12 +278,8 @@ export class SubstanceService extends BaseHttpService {
         if (order != null && order !== '') {
           params = params.append('order', order);
         }
-        console.log(url);
-        console.log(params);
 
       } else {
-        console.log(sync);
-        console.log(type);
         params = params.append('q', (searchTerm));
         if (type) {
           params = params.append('type', type);
@@ -287,7 +304,6 @@ export class SubstanceService extends BaseHttpService {
           }
         }
         url += 'substances/structureSearch';
-        console.log(url);
       }
 
       const options = {
@@ -296,10 +312,8 @@ export class SubstanceService extends BaseHttpService {
 
       this.http.get<any>(url, options).subscribe(
         response => {
-          console.log(response);
           // call async
           if (response.results) {
-            console.log('call async');
             const resultKey = response.key;
             this.searchKeys[structureFacetsKey] = resultKey;
             this.processAsyncSearchResults(
@@ -314,7 +328,6 @@ export class SubstanceService extends BaseHttpService {
               skip
             );
           } else {
-            console.log('complete');
             observer.next(response);
             observer.complete();
           }
@@ -460,8 +473,6 @@ export class SubstanceService extends BaseHttpService {
         response => {
           // call async
           if (response.results) {
-            console.log('has results');
-            console.log(response);
             const resultKey = response.key;
             this.searchKeys[bulkFacetsKey] = resultKey;
             this.processAsyncSearchResults(
@@ -477,7 +488,6 @@ export class SubstanceService extends BaseHttpService {
             );
           } else {
             // consider making API backend provide statusKey in JSON
-            console.log('not results)');
             if(this.searchKeys && this.searchKeys[bulkFacetsKey]) {
               response.statusKey = this.searchKeys[bulkFacetsKey];
             }
@@ -504,51 +514,58 @@ export class SubstanceService extends BaseHttpService {
     skip?: number,
     view?: string
   ): void {
-    console.log(asyncCallResponse);
-    this.getAsyncSearchResults(
-      querySearchTerm,
-      searchKey,
-      pageSize,
-      facets,
-      skip,
-      view
-    )
-      .subscribe(response => {
-        // consider making API backend provide statusKey in JSON
-        response.statusKey=searchKey;
-        response.finished = asyncCallResponse.finished;
-        observer.next(response);
-        if (!asyncCallResponse.finished) {
-          console.log('not finished');
-          this.http.get<any>(url, httpCallOptions).subscribe(searchResponse => {
+    this.tempObject = {
+      querySearchTerm: querySearchTerm,
+      url: url,
+      asyncCallResponse: asyncCallResponse,
+      observer: observer,
+      searchKey: searchKey,
+      httpCallOptions: httpCallOptions,
+      pageSize: pageSize ? pageSize : 0,
+      facets: facets ? facets : null,
+      skip: skip ? skip : 0,
+      view: view ? view : null
+    }
+    this.getAsyncSearchResults(querySearchTerm, searchKey, pageSize, facets, skip, view)
+      .pipe(
+        switchMap(response => {
+          let temp:any = response;
+          temp.statusKey = searchKey;
+          temp.finished = asyncCallResponse.finished;
+          observer.next(temp);
 
-            setTimeout(() => {
-
-              this.processAsyncSearchResults(
-                querySearchTerm,
-                url,
-                searchResponse,
-                observer,
-                searchKey,
-                httpCallOptions,
-                pageSize,
-                facets,
-                skip,
-                view
-              );
-            });
-          }, error => {
-            observer.error(error);
+          if (asyncCallResponse.finished) {
             observer.complete();
+            return [];
+          }
+
+          return this.http.get<any>(url, httpCallOptions).pipe(
+            takeWhile(() => !this.pauseSubject.getValue()) // Pause search in browse
+          );
+        })
+      )
+      .subscribe(
+        searchResponse => {
+          setTimeout(() => {
+            this.processAsyncSearchResults(
+              querySearchTerm,
+              url,
+              searchResponse,
+              observer,
+              searchKey,
+              httpCallOptions,
+              pageSize,
+              facets,
+              skip,
+              view
+            );
           });
-        } else {
+        },
+        error => {
+          observer.error(error);
           observer.complete();
         }
-      }, error => {
-        observer.error(error);
-        observer.complete();
-      });
-
+      );
   }
 
 

--- a/src/app/core/substances-browse/substances-browse.component.html
+++ b/src/app/core/substances-browse/substances-browse.component.html
@@ -118,15 +118,6 @@
 
 
     </div>
-    <div class="mat-elevation-z2 smiles-structure-result" style = "">
-      <div style = "width:100%;margin:20px">
-        <button (click) = "pauseStructureSearch = !pauseStructureSearch">PAUSE</button>{{pauseStructureSearch}}
-      </div>
-      <br/>
-    <div style = "width:100%; margin-bottom:5px;">
-      {{asyncFinished}}
-    </div>
-    </div>
 
     <div *ngIf="bulkSearchQueryId">
       <mat-expansion-panel [expanded]="bulkSearchPanelOpen" (opened)="bulkSearchPanelOpen = true" (closed)="bulkSearchPanelOpen = false"
@@ -160,6 +151,22 @@
 
     <div class="break"></div>
     <div class="side-nav-content" *ngIf="(substances && substances.length) || (matchTypes && matchTypes.length > 0)">
+      <div class = "narrow-search-suggestions-container"  *ngIf = "resultsInitiated  && this.structureDialogCanceled && !asyncFinished">
+      <div class="mat-elevation-z2 structure-search-status">
+        <div style = "margin:20px">
+          <span class = "structure-search-header">Structure Search is <b>{{pauseStructureSearch ? "PAUSED":"Processing.."}}</b></span>
+          <button mat-button  mat-raised-button class = "primary mat-primary structure-dialog-button" (click) = "pauseAsync(true)" *ngIf="!pauseStructureSearch">Pause Search</button>
+          <button mat-button mat-raised-button class = "primary mat-primary structure-dialog-button" (click) = "pauseAsync(false)" *ngIf="pauseStructureSearch">Resume Search</button>
+        </div>
+        <div><mat-progress-spinner *ngIf = "!pauseStructureSearch"
+          class="spinner"
+          [color]="primary"
+          [diameter]="30"
+          mode = "indeterminate">
+      </mat-progress-spinner></div>
+      </div>
+    </div>
+
       <div class="narrow-search-suggestions-container"
         *ngIf="matchTypes && matchTypes.length > 0; else filterParameters">
         <div class = "flex-row">
@@ -699,3 +706,19 @@
 
   </div>
 </div>
+
+
+<ng-template #structureRefTemplate class = "structure-template">
+<mat-dialog>
+
+
+    <div style = "width:90%;" *ngIf = "resultsInitiated">
+      <h3>SubStructure Search is Processing...</h3><br/>
+      Returning all results may take some time depending on the query. <br/><br/>You may pause the search to view the current results and resume the search afterwards.<br/><br/>
+      <!--<button mat-button class = "primary" (click) = "pauseStructureSearch = !pauseStructureSearch">{{pauseStructureSearch ? 'RESUME':'PAUSE'}}</button>-->
+    </div>
+    <mat-dialog-actions><span class = "middle-fill"></span><button mat-button class = "primary mat-raised-button mat-primary structure-dialog-button" (click) = "pauseCloseAsync()" >close dialog</button></mat-dialog-actions>
+  </mat-dialog>
+</ng-template>
+
+

--- a/src/app/core/substances-browse/substances-browse.component.html
+++ b/src/app/core/substances-browse/substances-browse.component.html
@@ -694,8 +694,8 @@
 
 
     <div style = "width:90%;" *ngIf = "resultsInitiated">
-      <h3>Substructure Search is Processing...</h3><br/>
-      Returning all results may take some time depending on the query. <br/><br/>The results will refresh once the search is complete. <br/>You may close this dialog to browse the incomplete results.<br/><br/>
+      <h3>{{privateSearchType | titlecase }} Search is Processing...</h3><br/>
+     <div class = "structure-dialog-content"> Returning all results may take some time depending on the query. <br/>The results will refresh once the search is complete. <br/>You may close this dialog to browse the incomplete results.</div><br/><br/>
       <!--<button mat-button class = "primary" (click) = "pauseStructureSearch = !pauseStructureSearch">{{pauseStructureSearch ? 'RESUME':'PAUSE'}}</button>-->
     </div>
     <mat-dialog-actions><span class = "middle-fill"></span><button mat-button class = "primary mat-raised-button mat-primary structure-dialog-button" (click) = "pauseCloseAsync()" >Close dialog</button></mat-dialog-actions>

--- a/src/app/core/substances-browse/substances-browse.component.html
+++ b/src/app/core/substances-browse/substances-browse.component.html
@@ -76,6 +76,26 @@
         </a></div>
         </div>
 
+
+
+
+
+
+
+
+
+
+       
+
+
+
+
+
+
+
+
+        
+
         <div class="mat-elevation-z2" *ngIf="sequenceSearchTerm">
           <div>
             <span class="capitalized font-medium-bold no-break">Sequence Query:</span>
@@ -97,6 +117,15 @@
       </div>
 
 
+    </div>
+    <div class="mat-elevation-z2 smiles-structure-result" style = "">
+      <div style = "width:100%;margin:20px">
+        <button (click) = "pauseStructureSearch = !pauseStructureSearch">PAUSE</button>{{pauseStructureSearch}}
+      </div>
+      <br/>
+    <div style = "width:100%; margin-bottom:5px;">
+      {{asyncFinished}}
+    </div>
     </div>
 
     <div *ngIf="bulkSearchQueryId">

--- a/src/app/core/substances-browse/substances-browse.component.html
+++ b/src/app/core/substances-browse/substances-browse.component.html
@@ -131,12 +131,13 @@
 
     <div class="break"></div>
     <div class="side-nav-content" *ngIf="(substances && substances.length) || (matchTypes && matchTypes.length > 0)">
-      <div class = "narrow-search-suggestions-container"  *ngIf = "resultsInitiated  && this.structureDialogCanceled && !asyncFinished">
-      <div class="mat-elevation-z2 structure-search-status">
+      <div class = "narrow-search-suggestions-container"  >
+      <div class="mat-elevation-z2 structure-search-status"  *ngIf = "resultsInitiated  && this.structureDialogCanceled && !asyncFinished">
         <div style = "margin:20px">
-          <span class = "structure-search-header">Structure Search is <b>{{pauseStructureSearch ? "PAUSED":"Processing.."}}</b></span>
+          <span class = "structure-search-header">Structure Search is Processing...</span>
+      <!--   <span class = "structure-search-header">Structure Search is <b>{{pauseStructureSearch ? "PAUSED":"Processing.."}}</b></span>
           <button mat-button  mat-raised-button class = "primary mat-primary structure-dialog-button" (click) = "pauseAsync(true)" *ngIf="!pauseStructureSearch">Pause Search</button>
-          <button mat-button mat-raised-button class = "primary mat-primary structure-dialog-button" (click) = "pauseAsync(false)" *ngIf="pauseStructureSearch">Resume Search</button>
+          <button mat-button mat-raised-button class = "primary mat-primary structure-dialog-button" (click) = "pauseAsync(false)" *ngIf="pauseStructureSearch">Resume Search</button>-->
         </div>
         <div><mat-progress-spinner *ngIf = "!pauseStructureSearch"
           class="spinner"
@@ -693,11 +694,11 @@
 
 
     <div style = "width:90%;" *ngIf = "resultsInitiated">
-      <h3>SubStructure Search is Processing...</h3><br/>
-      Returning all results may take some time depending on the query. <br/><br/>You may pause the search to view the current results and resume the search afterwards.<br/><br/>
+      <h3>Substructure Search is Processing...</h3><br/>
+      Returning all results may take some time depending on the query. <br/><br/>The results will refresh once the search is complete. <br/>You may close this dialog to browse the incomplete results.<br/><br/>
       <!--<button mat-button class = "primary" (click) = "pauseStructureSearch = !pauseStructureSearch">{{pauseStructureSearch ? 'RESUME':'PAUSE'}}</button>-->
     </div>
-    <mat-dialog-actions><span class = "middle-fill"></span><button mat-button class = "primary mat-raised-button mat-primary structure-dialog-button" (click) = "pauseCloseAsync()" >close dialog</button></mat-dialog-actions>
+    <mat-dialog-actions><span class = "middle-fill"></span><button mat-button class = "primary mat-raised-button mat-primary structure-dialog-button" (click) = "pauseCloseAsync()" >Close dialog</button></mat-dialog-actions>
   </mat-dialog>
 </ng-template>
 

--- a/src/app/core/substances-browse/substances-browse.component.html
+++ b/src/app/core/substances-browse/substances-browse.component.html
@@ -42,59 +42,39 @@
         </div>
         <div class="mat-elevation-z2 smiles-structure-result" style = "" *ngIf="smiles">
           <div style = "width:100%">
-          <div>
-            <span class="capitalized font-medium-bold no-break">{{structureSearchTerm && searchType}} Query:</span>
-            &nbsp;
-            <span class="no-break">
-                <input readonly [value] = "this.smiles" class = "smiles-input" />
-                <button mat-icon-button color="primary" (click)="copySmiles(this.smiles)">
-                    <mat-icon svgIcon="paste" matTooltip = "Copy Smiles to clipboard"></mat-icon>
-                  </button>
+            <div>
+              <span class="capitalized font-medium-bold no-break">{{structureSearchTerm && searchType}} Query:</span>
+              &nbsp;
+              <span class="no-break">
+                  <input readonly [value] = "this.smiles" class = "smiles-input" />
+                  <button mat-icon-button color="primary" (click)="copySmiles(this.smiles)">
+                      <mat-icon svgIcon="paste" matTooltip = "Copy Smiles to clipboard"></mat-icon>
+                    </button>
 
-              <span *ngIf="searchType && searchType == 'similarity'">
-                &nbsp;&ge; {{searchCutoff}}
+                <span *ngIf="searchType && searchType == 'similarity'">
+                  &nbsp;&ge; {{searchCutoff}}
+                </span>
               </span>
-            </span>
-            <span class="actions-container">
-                <button mat-icon-button color="primary" (click)="editStructureSearch()">
-                  <mat-icon svgIcon="edit" matTooltip = "edit structure search parameters"></mat-icon>
-                </button>
-                <button mat-icon-button color="primary" (click)="clearStructureSearch()">
-                  <mat-icon svgIcon="delete_forever" matTooltip = "clear structure search parameters"></mat-icon>
-                </button>
-              </span>
+              <span class="actions-container">
+                  <button mat-icon-button color="primary" (click)="editStructureSearch()">
+                    <mat-icon svgIcon="edit" matTooltip = "edit structure search parameters"></mat-icon>
+                  </button>
+                  <button mat-icon-button color="primary" (click)="clearStructureSearch()">
+                    <mat-icon svgIcon="delete_forever" matTooltip = "clear structure search parameters"></mat-icon>
+                  </button>
+                </span>
+
+            </div>
+
 
           </div>
+            <br/>
+          <div style = "width:100%; margin-bottom:5px;">
 
-
+            <a color="primary" class = "link" (click)="seedSmiles(this.smiles)">
+            Or start a new chemical registration using this Smiles
+          </a></div>
         </div>
-          <br/>
-        <div style = "width:100%; margin-bottom:5px;">
-
-          <a color="primary" class = "link" (click)="seedSmiles(this.smiles)">
-          Or start a new chemical registration using this Smiles
-        </a></div>
-        </div>
-
-
-
-
-
-
-
-
-
-
-       
-
-
-
-
-
-
-
-
-        
 
         <div class="mat-elevation-z2" *ngIf="sequenceSearchTerm">
           <div>

--- a/src/app/core/substances-browse/substances-browse.component.scss
+++ b/src/app/core/substances-browse/substances-browse.component.scss
@@ -745,7 +745,7 @@ margin-left: 20px;
     display:flex;
     flex-direction:row;
     margin:20px;
-    width:50%;
+    width:425px;
 }
 
 .structure-dialog-button {
@@ -760,9 +760,9 @@ margin-left: 20px;
 .spinner {
     height: 30px;
     width: 30px;
-    margin-left: 25px;
+    margin-left: 15px;
     margin-right: 10px;
-    margin-top: 25px;
+    margin-top: 18px;
 }
 
 ::ng-deep #structure-dialog {

--- a/src/app/core/substances-browse/substances-browse.component.scss
+++ b/src/app/core/substances-browse/substances-browse.component.scss
@@ -769,3 +769,9 @@ margin-left: 20px;
     margin-bottom: 300px !important;
 }
 
+
+.structure-dialog-content {
+ line-height: 28px;
+ margin-left: 20px;
+}
+

--- a/src/app/core/substances-browse/substances-browse.component.scss
+++ b/src/app/core/substances-browse/substances-browse.component.scss
@@ -740,3 +740,32 @@ margin-left: 20px;
     flex-direction:column;
     max-width: 650px;
 }
+
+.structure-search-status {
+    display:flex;
+    flex-direction:row;
+    margin:20px;
+    width:50%;
+}
+
+.structure-dialog-button {
+    font-size: 16px;
+}
+
+.structure-search-header {
+    margin: 25px;
+    font-size:18px;
+}
+
+.spinner {
+    height: 30px;
+    width: 30px;
+    margin-left: 25px;
+    margin-right: 10px;
+    margin-top: 25px;
+}
+
+::ng-deep #structure-dialog {
+    margin-bottom: 300px !important;
+}
+

--- a/src/app/core/substances-browse/substances-browse.component.ts
+++ b/src/app/core/substances-browse/substances-browse.component.ts
@@ -227,6 +227,7 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
     this.setUpPrivateSearchTerm();
 
     this.privateStructureSearchTerm = this.activatedRoute.snapshot.queryParams['structure_search'] || '';
+    this.substanceService.unpauseAsyncSubject();
     this.privateSequenceSearchTerm = this.activatedRoute.snapshot.queryParams['sequence_search'] || '';
     this.privateSequenceSearchKey = this.activatedRoute.snapshot.queryParams['sequence_key'] || '';
     this.privateBulkSearchQueryId = this.activatedRoute.snapshot.queryParams['bulkQID'] || '';
@@ -350,6 +351,8 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
     this.subscriptions.forEach(subscription => {
       subscription.unsubscribe();
     });
+    this.substanceService.pauseAsyncSearch();
+    this.substanceService.clearSearchKey();
     this.facetManagerService.unregisterFacetSearchHandler();
   }
 
@@ -572,7 +575,7 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
          if((this.privateSearchType === 'substructure') && iterations === 0) {
           this.resultsInitiated = true;
           this.openModal();
-          this.pauseStructureSearch = true;
+        // this.pauseStructureSearch = true;
            iterations++;
          }
          
@@ -602,7 +605,7 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
           }
 
         //  if(!this.pauseStructureSearch || pagingResponse.finished){
-        if( this.privateSearchType === 'substructure'){
+       if( this.privateSearchType === 'substructure'){
           if (pagingResponse.finished || iterations === 1){
             this.substances = pagingResponse.content;
             iterations++;
@@ -610,7 +613,6 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
         }else {
           this.substances = pagingResponse.content;
         }
-
 
           this.totalSubstances = pagingResponse.total;
           this.etag = pagingResponse.etag;
@@ -695,7 +697,7 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
             this.asyncFinished = true;
          this.substances = pagingResponse.content;
          setTimeout(()=>{
-          this.structureSearchDialog.close();
+          this.structureSearchDialog ? this.structureSearchDialog.close() : null;
          }, 700);
           }
           this.substanceService.setResult(pagingResponse.etag, pagingResponse.content, pagingResponse.total);
@@ -726,6 +728,7 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
           this.isLoading = false;
           this.loadingService.setLoading(this.isLoading);
         });
+        this.subscriptions.push(subscription);
     }
 
   }

--- a/src/app/core/substances-browse/substances-browse.component.ts
+++ b/src/app/core/substances-browse/substances-browse.component.ts
@@ -19,7 +19,7 @@ import * as _ from 'lodash';
 import { LoadingService } from '../loading/loading.service';
 import { MainNotificationService } from '../main-notification/main-notification.service';
 import { AppNotification, NotificationType } from '../main-notification/notification.model';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog} from '@angular/material/dialog';
 import { PageEvent } from '@angular/material/paginator';
 import { UtilsService } from '../utils/utils.service';
 import { MatSidenav } from '@angular/material/sidenav';
@@ -138,8 +138,15 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
   facetViewControl = new FormControl();
   private wildCardText: string;
   bulkSearchPanelOpen = false;
+
+  //async substructure search and dialog
+  structureSearchDialog: any;
   pauseStructureSearch = false;
   asyncFinished = false;
+  structureDialogOpened = false;
+  structureDialogCanceled = false;
+  resultsInitiated = false;
+  @ViewChild('structureRefTemplate') structureTemplateRef: TemplateRef<any>;
 
 
   constructor(
@@ -392,6 +399,8 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
     this.pageIndex = pageEvent.pageIndex;
     this.populateUrlQueryParameters();
     this.searchSubstances();
+    setTimeout(()=>{     this.pauseAsync(false);
+    });
   }
 
   customPage(event: any): void {
@@ -402,6 +411,8 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
       this.gaService.sendEvent('substancesContent', 'select:page-number', 'pager', newpage);
       this.populateUrlQueryParameters();
       this.searchSubstances();
+      setTimeout(()=>{     this.pauseAsync(false);
+      });
     }
   }
 
@@ -473,14 +484,51 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
     }
   }
 
-  pause() {}
+  pauseAsync(pause:boolean) {
+    this.pauseStructureSearch = pause;
+    if (pause) {
+      this.substanceService.pauseAsyncSearch();
+    } else {
+      this.substanceService.resumeAsyncSearch();
+    }
+  }
+
+  //Co nsider just making this close, no pause
+  pauseCloseAsync() {
+ //   this.substanceService.pauseAsyncSearch();
+  //  this.pauseStructureSearch = true;
+  this.pauseStructureSearch = false;
+    this.structureSearchDialog.close();
+  }
+
+  openModal() {
+
+    if(!this.structureDialogOpened) {
+      this.structureSearchDialog = this.dialog.open(this.structureTemplateRef, {
+        maxHeight: '50%',
+        width: '750px',
+        panelClass: 'structure-dialog',
+        id:'structure-dialog'
+      });
+      this.overlayContainer.style.zIndex = '1002';
+  
+      this.structureSearchDialog.afterClosed().subscribe(result => {
+        this.overlayContainer.style.zIndex = null;
+        this.loadingService.setLoading(false);
+        this.structureDialogCanceled = true;
+
+      });
+      this.structureDialogOpened = true;
+    }
+    
+  }
 
   searchSubstances() {
       // There should be a better way to do this.
       this.bulkSearchPanelOpen =
       (this.privateSearchTerm ===undefined || this.privateSearchTerm ==='')
       && (this.displayFacets && this.displayFacets.length===0);
-
+    let iterations = 0;
     this.disableExport = false;
     const newArgsHash = this.utilsService.hashCode(
       this.privateSearchTerm,
@@ -520,10 +568,14 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
       })
         .subscribe(pagingResponse => {
           //remove later
-          this.loadingService.setLoading(false);
-
-          console.log('BROWSE PAGING RESPONSE');
-          console.log(pagingResponse);
+         // this.loadingService.setLoading(false);
+         if((this.privateSearchType === 'substructure') && iterations === 0) {
+          this.resultsInitiated = true;
+          this.openModal();
+          this.pauseStructureSearch = true;
+           iterations++;
+         }
+         
 
           this.privateBulkSearchStatusKey = pagingResponse.statusKey;
           this.isError = false;
@@ -549,10 +601,17 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
             this.privateBulkSearchSummary = pagingResponse.summary;
           }
 
-          if(!this.pauseStructureSearch){
+        //  if(!this.pauseStructureSearch || pagingResponse.finished){
+        if( this.privateSearchType === 'substructure'){
+          if (pagingResponse.finished || iterations === 1){
             this.substances = pagingResponse.content;
+            iterations++;
           }
-          
+        }else {
+          this.substances = pagingResponse.content;
+        }
+
+
           this.totalSubstances = pagingResponse.total;
           this.etag = pagingResponse.etag;
           if (pagingResponse.facets && pagingResponse.facets.length > 0) {
@@ -634,8 +693,10 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
           });
           if(pagingResponse.finished){
             this.asyncFinished = true;
-            console.log(pagingResponse.finished);
-            console.log('BROWSE setting result');
+         this.substances = pagingResponse.content;
+         setTimeout(()=>{
+          this.structureSearchDialog.close();
+         }, 700);
           }
           this.substanceService.setResult(pagingResponse.etag, pagingResponse.content, pagingResponse.total);
         }, error => {
@@ -694,6 +755,7 @@ searchTermOkforBeginsWithSearch(): boolean {
         maxHeight: '85%',
 
         width: '60%',
+        
         data: { 'extension': extension }
       });
 

--- a/src/app/core/substances-browse/substances-browse.component.ts
+++ b/src/app/core/substances-browse/substances-browse.component.ts
@@ -572,7 +572,7 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
         .subscribe(pagingResponse => {
           //remove later
          // this.loadingService.setLoading(false);
-         if((this.privateSearchType === 'substructure') && iterations === 0) {
+         if((this.privateSearchType === 'substructure' || this.privateSearchType === 'similarity') && iterations === 0) {
           this.resultsInitiated = true;
           this.openModal();
         // this.pauseStructureSearch = true;
@@ -605,7 +605,7 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
           }
 
         //  if(!this.pauseStructureSearch || pagingResponse.finished){
-       if( this.privateSearchType === 'substructure'){
+       if( this.privateSearchType === 'substructure' || this.privateSearchType === 'similarity'){
           if (pagingResponse.finished || iterations === 1){
             this.substances = pagingResponse.content;
             iterations++;
@@ -698,7 +698,7 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
          this.substances = pagingResponse.content;
          setTimeout(()=>{
           this.structureSearchDialog ? this.structureSearchDialog.close() : null;
-         }, 700);
+         });
           }
           this.substanceService.setResult(pagingResponse.etag, pagingResponse.content, pagingResponse.total);
         }, error => {

--- a/src/app/core/substances-browse/substances-browse.component.ts
+++ b/src/app/core/substances-browse/substances-browse.component.ts
@@ -138,7 +138,8 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
   facetViewControl = new FormControl();
   private wildCardText: string;
   bulkSearchPanelOpen = false;
-
+  pauseStructureSearch = false;
+  asyncFinished = false;
 
 
   constructor(
@@ -472,6 +473,8 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
     }
   }
 
+  pause() {}
+
   searchSubstances() {
       // There should be a better way to do this.
       this.bulkSearchPanelOpen =
@@ -516,6 +519,12 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
         deprecated: this.showDeprecated
       })
         .subscribe(pagingResponse => {
+          //remove later
+          this.loadingService.setLoading(false);
+
+          console.log('BROWSE PAGING RESPONSE');
+          console.log(pagingResponse);
+
           this.privateBulkSearchStatusKey = pagingResponse.statusKey;
           this.isError = false;
           this.totalSubstances = pagingResponse.total;
@@ -540,7 +549,10 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
             this.privateBulkSearchSummary = pagingResponse.summary;
           }
 
-          this.substances = pagingResponse.content;
+          if(!this.pauseStructureSearch){
+            this.substances = pagingResponse.content;
+          }
+          
           this.totalSubstances = pagingResponse.total;
           this.etag = pagingResponse.etag;
           if (pagingResponse.facets && pagingResponse.facets.length > 0) {
@@ -620,6 +632,11 @@ export class SubstancesBrowseComponent implements OnInit, AfterViewInit, OnDestr
               return true;
             });
           });
+          if(pagingResponse.finished){
+            this.asyncFinished = true;
+            console.log(pagingResponse.finished);
+            console.log('BROWSE setting result');
+          }
           this.substanceService.setResult(pagingResponse.etag, pagingResponse.content, pagingResponse.total);
         }, error => {
           this.gaService.sendException('getSubstancesDetails: error from API call');

--- a/src/app/core/utils/paging-response.model.ts
+++ b/src/app/core/utils/paging-response.model.ts
@@ -26,6 +26,8 @@ export interface PagingResponse<T> {
     facets?: Array<Facet>;
     filter?: string;
     summary?: any; // added for bulk search
+    status?: string;
+    finished?: boolean;
 }
 
 export interface NarrowSearchSuggestion {

--- a/src/app/fda/config/config.json
+++ b/src/app/fda/config/config.json
@@ -10,6 +10,7 @@
   "bannerMessage": null,
   "showNameStandardizeButton": true,
   "advancedSearchFacetDisplay": false,
+  "apiBaseUrl": "https://gsrs.ncats.nih.gov/ginas/app/",
   "approvalCodeName": "UNII",
   "primaryCode": "BDNUM",
   "useDataUrl": false,

--- a/src/app/fda/config/config.json
+++ b/src/app/fda/config/config.json
@@ -10,7 +10,6 @@
   "bannerMessage": null,
   "showNameStandardizeButton": true,
   "advancedSearchFacetDisplay": false,
-  "apiBaseUrl": "https://gsrs.ncats.nih.gov/ginas/app/",
   "approvalCodeName": "UNII",
   "primaryCode": "BDNUM",
   "useDataUrl": false,


### PR DESCRIPTION
Fixes weird loading appearance of substructure searches. Now opens a dialog explaining that the search may take some time with the option to close and view results before all have been processed. Optional pause and resume for the async calls, flickering refreshes are disabled.

Also includes changes to baseUrl for files opened in new dialog in line with 3.1.1 changes for users without that config value explicitly set.