### PR TITLE
Restore code for substance selector

### DIFF
--- a/src/app/core/config/config.pfda.json
+++ b/src/app/core/config/config.pfda.json
@@ -530,7 +530,8 @@
     "root_approvalID",
     "root_codes_BDNUM",
     "root_codes_CAS",
-    "root_codes_ECHA\\ \\(EC\/EINECS\\)"
+    "root_codes_ECHA",
+    "root_codes_EINECS"
   ],
   "contactEmail": "precisionfda-support@dnanexus.com",
   "sessionExpirationWarning": {

--- a/src/app/core/config/config.pfda.json
+++ b/src/app/core/config/config.pfda.json
@@ -530,8 +530,7 @@
     "root_approvalID",
     "root_codes_BDNUM",
     "root_codes_CAS",
-    "root_codes_ECHA",
-    "root_codes_EINECS"
+    "root_codes_ECHA"
   ],
   "contactEmail": "precisionfda-support@dnanexus.com",
   "sessionExpirationWarning": {

--- a/src/app/core/substance-selector/substance-selector.component.ts
+++ b/src/app/core/substance-selector/substance-selector.component.ts
@@ -101,6 +101,8 @@ export class SubstanceSelectorComponent implements OnInit {
     const searchStr = this.substanceSelectorProperties.map(property => `${property}:\"^${q}$\"`).join(' OR ');
 
     this.substanceService.getQuickSubstancesSummaries(searchStr, true).subscribe(response => {
+      console.log(`processSubstanceSearch response: ${JSON.stringify(response)}`);
+      response.total
       if (response.content && response.content.length) {
         this.selectedSubstance = response.content[0];
         this.selectionUpdated.emit(this.selectedSubstance);
@@ -111,63 +113,6 @@ export class SubstanceSelectorComponent implements OnInit {
     });
   }
   
-  processSubstanceSearchNew(searchValue: string = ''): void {
-    const q = searchValue.replace('\"', '');
-    const searchStr = this.substanceSelectorProperties.map(property => `${property}:\"^${q}$\"`).join(' OR ');
-    console.log(`q: ${q}; searchStr: ${searchStr}`);
-    this.substanceService.getQuickSubstancesSummaries(searchStr, true).subscribe(response => {
-      console.log(`response: ${JSON.stringify(response)}`);
-      if (response.content && response.content.length) {
-        console.log('response has content');
-        let found = false;
-        // Loop through the search results and compare the search term with search result's _name field
-        for (let i = 0; i < response.content.length; i++) {
-          let substance = response.content[i];
-          if( (substance.uuid != null && substance.uuid === searchValue) || 
-            (substance.approvalID !== null && substance.approvalID === searchValue)) {
-            found = true;
-            this.selectedSubstance = substance;
-            this.selectionUpdated.emit(this.selectedSubstance);
-            console.log('found match for UUID and/or approval ID');
-            return;
-          }
-
-          this.substanceService.getSubstanceNames(substance.uuid).subscribe(names => {
-            if (names && names.some(n=>n.name === searchValue)) {
-
-              // set to true, since search value matches with search result's _name field
-              found = true;
-              
-              this.selectedSubstance = substance;
-              this.selectionUpdated.emit(this.selectedSubstance);
-              console.log('found match for name');
-              // break out of the loop when name found
-              return;
-            }
-          });
-          this.substanceService.getSubstanceCodes(substance.uuid).subscribe(codes => {
-            if(codes && codes.some(c=>c.code === searchValue)){
-              found = true;
-              this.selectedSubstance = substance;
-              this.selectionUpdated.emit(this.selectedSubstance);
-              console.log('found match for code');
-              return;
-            }
-          });
-        }
-        // If Ingredient Name not found into the database, display message
-        if (found == false) {
-          this.errorMessage = 'No substances found';
-        } else {
-          this.errorMessage = '';
-        }
-      } else {
-        this.errorMessage = 'No substances found';
-      }
-    });
-  }
-
- 
 
   advanced(type: string): void {
 

--- a/src/app/core/substance-selector/substance-selector.component.ts
+++ b/src/app/core/substance-selector/substance-selector.component.ts
@@ -99,12 +99,38 @@ export class SubstanceSelectorComponent implements OnInit {
   processSubstanceSearch(searchValue: string = ''): void {
     const q = searchValue.replace('\"', '');
     const searchStr = this.substanceSelectorProperties.map(property => `${property}:\"^${q}$\"`).join(' OR ');
+
     this.substanceService.getQuickSubstancesSummaries(searchStr, true).subscribe(response => {
       if (response.content && response.content.length) {
+        this.selectedSubstance = response.content[0];
+        this.selectionUpdated.emit(this.selectedSubstance);
+        this.errorMessage = '';
+      } else {
+        this.errorMessage = 'No substances found';
+      }
+    });
+  }
+  
+  processSubstanceSearchNew(searchValue: string = ''): void {
+    const q = searchValue.replace('\"', '');
+    const searchStr = this.substanceSelectorProperties.map(property => `${property}:\"^${q}$\"`).join(' OR ');
+    console.log(`q: ${q}; searchStr: ${searchStr}`);
+    this.substanceService.getQuickSubstancesSummaries(searchStr, true).subscribe(response => {
+      console.log(`response: ${JSON.stringify(response)}`);
+      if (response.content && response.content.length) {
+        console.log('response has content');
         let found = false;
         // Loop through the search results and compare the search term with search result's _name field
         for (let i = 0; i < response.content.length; i++) {
           let substance = response.content[i];
+          if( (substance.uuid != null && substance.uuid === searchValue) || 
+            (substance.approvalID !== null && substance.approvalID === searchValue)) {
+            found = true;
+            this.selectedSubstance = substance;
+            this.selectionUpdated.emit(this.selectedSubstance);
+            console.log('found match for UUID and/or approval ID');
+            return;
+          }
 
           this.substanceService.getSubstanceNames(substance.uuid).subscribe(names => {
             if (names && names.some(n=>n.name === searchValue)) {
@@ -114,11 +140,20 @@ export class SubstanceSelectorComponent implements OnInit {
               
               this.selectedSubstance = substance;
               this.selectionUpdated.emit(this.selectedSubstance);
-
+              console.log('found match for name');
               // break out of the loop when name found
               return;
             }
-          }); 
+          });
+          this.substanceService.getSubstanceCodes(substance.uuid).subscribe(codes => {
+            if(codes && codes.some(c=>c.code === searchValue)){
+              found = true;
+              this.selectedSubstance = substance;
+              this.selectionUpdated.emit(this.selectedSubstance);
+              console.log('found match for code');
+              return;
+            }
+          });
         }
         // If Ingredient Name not found into the database, display message
         if (found == false) {

--- a/src/app/core/substance-selector/substance-selector.component.ts
+++ b/src/app/core/substance-selector/substance-selector.component.ts
@@ -98,11 +98,29 @@ export class SubstanceSelectorComponent implements OnInit {
 
   processSubstanceSearch(searchValue: string = ''): void {
     const q = searchValue.replace('\"', '');
+    if( this.substanceService.isUUID(q)) {
+      console.log('detected a UUID')
+      this.substanceService.getSubstanceDetails(q).subscribe( {
+        next: response => {
+        if(response && response != null) {
+          this.selectedSubstance = response;
+          this.selectionUpdated.emit(this.selectedSubstance);
+          this.errorMessage = '';
+          console.log('got substance via UUID');
+        } else {
+          console.log('no match for UUID');
+          this.errorMessage = 'No substances found';
+        }
+        },
+        error: err=>{
+          console.log('error retrieving UUID');
+          this.errorMessage = 'No substances found';
+        }
+      });
+      return;
+    } 
     const searchStr = this.substanceSelectorProperties.map(property => `${property}:\"^${q}$\"`).join(' OR ');
-
     this.substanceService.getQuickSubstancesSummaries(searchStr, true).subscribe(response => {
-      console.log(`processSubstanceSearch response: ${JSON.stringify(response)}`);
-      response.total
       if (response.content && response.content.length) {
         this.selectedSubstance = response.content[0];
         this.selectionUpdated.emit(this.selectedSubstance);

--- a/src/app/core/substance/substance.service.ts
+++ b/src/app/core/substance/substance.service.ts
@@ -753,7 +753,15 @@ export class SubstanceService extends BaseHttpService {
     const options = {
       params: params
     };
+    console.log(`url: ${url} parms ${options.params}`);
     return this.http.get<PagingResponse<SubstanceSummary>>(url, options);
+  }
+
+  isUUID(uuidCandidate) {
+    if ((uuidCandidate + "").match(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/)) {
+        return true;
+    }
+    return false;
   }
 
   getAllByEtag(etag: string) {
@@ -1154,9 +1162,3 @@ export class SubstanceService extends BaseHttpService {
     return this.http.get<SubstanceDetail>(url);
   }
 }
-
-
-
-
-
-

--- a/src/app/core/substance/substance.service.ts
+++ b/src/app/core/substance/substance.service.ts
@@ -753,7 +753,6 @@ export class SubstanceService extends BaseHttpService {
     const options = {
       params: params
     };
-
     return this.http.get<PagingResponse<SubstanceSummary>>(url, options);
   }
 

--- a/src/app/fda/config/config.json
+++ b/src/app/fda/config/config.json
@@ -1373,9 +1373,7 @@
     "root_approvalID",
     "root_codes_BDNUM",
     "root_codes_CAS",
-    "root_codes_ECHA",
-    "root_codes_EC",
-    "root_codes_EINECS"
+    "root_codes_ECHA"
   ],
   "homeDynamicLinks": [
     {

--- a/src/app/fda/config/config.json
+++ b/src/app/fda/config/config.json
@@ -1373,7 +1373,9 @@
     "root_approvalID",
     "root_codes_BDNUM",
     "root_codes_CAS",
-    "root_codes_ECHA\\ \\(EC\\/EINECS\\)"
+    "root_codes_ECHA",
+    "root_codes_EC",
+    "root_codes_EINECS"
   ],
   "homeDynamicLinks": [
     {


### PR DESCRIPTION
So that all types of searches previously supported work.
Fixed config so that queries that have no real results do not return bogus records