### PR TITLE
Fix UI not updating after first login on cold start

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, PLATFORM_ID, Inject } from '@angular/core';
 import { ConfigService } from '../config/config.service';
 import { Auth, Privilege, Role, UserGroup } from './auth.model';
-import { from, Observable, Subject, throwError, of, firstValueFrom } from 'rxjs';
+import { from, Observable, BehaviorSubject, of, firstValueFrom, throwError } from 'rxjs';
 import { map, take, catchError, concat, switchMap, tap } from 'rxjs/operators';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { isPlatformBrowser } from '@angular/common';
@@ -12,7 +12,7 @@ import { UserDownload, AllUserDownloads } from '@gsrs-core/auth/user-downloads/d
 })
 export class AuthService {
   private _auth: Auth;
-  private _authUpdate: Subject<Auth> = new Subject();
+  private _authUpdate = new BehaviorSubject<Auth | null>(null);
   private isLoading: boolean;
   private _privileges: Array<Privilege> = [];
 
@@ -81,60 +81,50 @@ get auth(): Auth {
       obs = of(this.configService.configData.dummyWhoami);
     }
     return obs.pipe(
-      map(auth => {
+      switchMap(auth => {
         if (auth && auth.computedToken) {
           this._auth = auth;
           if (isPlatformBrowser(this.platformId)) {
             sessionStorage.setItem('authToken', auth.computedToken);
           }
+          this._authUpdate.next(this._auth);
+          // Fetch privileges after successful login
+          return this.fetchPrivs().pipe(
+            map(() => this._auth),
+            catchError(() => {
+              // Privileges fetch failed, but auth succeeded - still return auth
+              return of(this._auth);
+            })
+          );
         } else {
           this._auth = null;
+          this._authUpdate.next(null);
+          return of(null);
         }
-
-        this._authUpdate.next(this._auth);
-        return this._auth;
       })
     );
   }
 
-  getAuth(): Observable<Auth> {
-    return new Observable(observer => {
-
-      if (this._auth != null) {
-        observer.next(this._auth);
-      } else if (!this.isLoading) {
-        this.isLoading = true;
-        this.fetchAuth().pipe(take(1)).subscribe(auth => {
-          if (auth && auth.computedToken != null) {
-            this._auth = auth;
-          } else {
-            this._auth = null;
-          }
-
-          observer.next(this._auth);
+  getAuth(): Observable<Auth | null> {
+    // Trigger a fetch if not loading and no auth yet
+    if (this._auth == null && !this.isLoading) {
+      this.isLoading = true;
+      this.fetchAuth().pipe(take(1)).subscribe({
+        next: auth => {
+          this._auth = auth?.computedToken ? auth : null;
           this._authUpdate.next(this._auth);
           this.isLoading = false;
-        }, error => {
-          this.logout();
+        },
+        error: () => {
+          this._auth = null;
+          this._authUpdate.next(null);
           this.isLoading = false;
-        });
-      }
-
-      this._authUpdate.subscribe(auth => {
-        try {
-          observer.next(auth);
-        } catch (e) {
-          console.log("Error calling observer");
-        }
-      }, error => {
-        console.log("Error calling observer, registered error");
-        try {
-          observer.next(null);
-        } catch (e) {
-          console.log("Error calling observer, registered error, passed null");
         }
       });
-    });
+    }
+
+    // Return the BehaviorSubject as observable - late subscribers get current value
+    return this._authUpdate.asObservable();
   }
 
   logout(): void {
@@ -244,7 +234,12 @@ get auth(): Auth {
   
   private async ensurePrivilegesLoaded(): Promise<void> {
     if (!this._privileges || this._privileges.length === 0) {
-      this._privileges = await firstValueFrom(this.fetchPrivs());
+      try {
+        this._privileges = await firstValueFrom(this.fetchPrivs());
+      } catch (e) {
+        // Not authenticated or fetch failed - use empty privileges
+        this._privileges = [];
+      }
     }
   }
 

--- a/src/app/core/base/base.component.ts
+++ b/src/app/core/base/base.component.ts
@@ -131,7 +131,23 @@ export class BaseComponent implements OnInit, OnDestroy {
     this.contactEmail = this.configService.configData.contactEmail || null;
     this.navItems = this.configService.configData.navItems || null;
 
-  let notempty = false;
+    // CRITICAL: Subscribe to auth FIRST, before any await calls that might fail
+    // This ensures UI updates reactively when auth state changes
+    const authSubscription = this.authService.getAuth().subscribe(auth => {
+      this.auth = auth;
+      // Re-check privileges when auth changes
+      if (auth) {
+        this.updatePrivileges();
+      } else {
+        this.canConfigureSystem = false;
+        this.canUserImportData = false;
+        this.canRegister = false;
+        this.canManageCVs = false;
+      }
+    });
+    this.subscriptions.push(authSubscription);
+
+    let notempty = false;
     if (this.loadedComponents) {
       if (this.loadedComponents.applications) {
         notempty = true;
@@ -151,10 +167,9 @@ export class BaseComponent implements OnInit, OnDestroy {
         this.loadedComponents = null;
       }
     }
-    this.canConfigureSystem = await this.authService.hasSpecificPrivilege('Configure System');
-    this.canUserImportData = await this.authService.hasSpecificPrivilege('Import Data');
-    this.canRegister=await this.authService.canEditData();
-    this.canManageCVs = await this.authService.hasSpecificPrivilege("Manage CVs");
+
+    // Initial privilege check with error handling
+    await this.updatePrivileges();
     //not sure if we need this.
     //  TODO: remove it and test that the component works.
     this.baseDomain = this.configService.configData.apiUrlDomain;
@@ -207,21 +222,14 @@ export class BaseComponent implements OnInit, OnDestroy {
     });
     this.subscriptions.push(paramsSubscription);
 
-    const authSubscription2 = this.authService.checkAuth().subscribe(auth => {
+    const authSubscription2 = this.authService.checkAuth().subscribe(_auth => {
     }, error => {
       if (error.status === 403 && (this.router.url.split('?')[0] !== '/login' && this.router.url.split('?')[0] !== '/unauthorized')) {
         this.loadingService.setLoading(false);
         this.router.navigate(['/unauthorized']);
       }
     });
-      this.subscriptions.push(authSubscription2);
-
-    const authSubscription = this.authService.getAuth().subscribe(auth => {
-      this.auth = auth;
-    }, error => {
-    });
-
-    this.subscriptions.push(authSubscription);
+    this.subscriptions.push(authSubscription2);
 
     this.environment = this.configService.environment;
     this.appId = this.environment.appId;
@@ -525,6 +533,25 @@ export class BaseComponent implements OnInit, OnDestroy {
 
 
     });
+  }
+
+  /**
+   * Updates privilege flags based on current auth state.
+   * Called on init and whenever auth changes.
+   */
+  private async updatePrivileges(): Promise<void> {
+    try {
+      this.canConfigureSystem = await this.authService.hasSpecificPrivilege('Configure System');
+      this.canUserImportData = await this.authService.hasSpecificPrivilege('Import Data');
+      this.canRegister = await this.authService.canEditData();
+      this.canManageCVs = await this.authService.hasSpecificPrivilege('Manage CVs');
+    } catch (e) {
+      // Not authenticated or error - all privileges default to false
+      this.canConfigureSystem = false;
+      this.canUserImportData = false;
+      this.canRegister = false;
+      this.canManageCVs = false;
+    }
   }
 
 }

--- a/src/app/fda/config/config.json
+++ b/src/app/fda/config/config.json
@@ -331,7 +331,7 @@
     },
     {
       "card": "substance-subunits",
-      "title": "Nuceic Acid Subunits",
+      "title": "Nucleic Acid Subunits",
       "filters": [
         {
           "filterName": "equals",


### PR DESCRIPTION
Fixes a cold-start timing issue where login succeeded but the UI did not update until a manual refresh.

On initial load, auth and privilege state were not propagated reactively, causing the header and privilege-based menus to render as unauthenticated. This was due to late auth subscriptions, non-replayed auth events, and privilege checks throwing during initialization.

Fixes:

1. Fetching privileges immediately after successful login
2. Make privilege loading non-throwing on cold start
3. Subscribe to auth state early and recompute privileges reactively
4. Using BehaviorSubject for auth to support late subscribers
5. Simplifying getAuth() to expose a stable auth stream
