### PR TITLE
user creation url

### DIFF
--- a/src/app/core/admin/admin.service.ts
+++ b/src/app/core/admin/admin.service.ts
@@ -101,7 +101,7 @@ export class AdminService extends BaseHttpService {
 
     public addUser(user: UserEditObject): Observable< Auth > {
       const url = `${(this.configService.configData && this.configService.configData.apiBaseUrl) || '/' }api/v1/`;
-      return this.http.post< Auth >(`${url}users/`, user);
+      return this.http.post< Auth >(`${url}users`, user);
     }
 
     public deleteUser(user: string): Observable< Auth > {


### PR DESCRIPTION
changing the URL used when creating new users to avoid 401 errors that appear with Spring Boot 3.5.7