### PR TITLE
ketcher isotope issue fix

### DIFF
--- a/src/app/core/structure-editor/molfile-isotope.util.spec.ts
+++ b/src/app/core/structure-editor/molfile-isotope.util.spec.ts
@@ -1,0 +1,351 @@
+import {
+  getCounts,
+  getAtomElements,
+  getBondLayout,
+  hasSameStructureLayout,
+  getIsoEntries,
+  formatIsoLines,
+  consolidateIsoLines,
+  restoreMissingIsoEntries,
+} from './molfile-isotope.util';
+
+// Molfile with three separate M  ISO lines.
+const ISOTOPES_MOL = ` JSDraw206032611132D
+
+ 13 14  0  0  0  0              0 V2000
+   13.0000   -5.6056    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.6490   -4.8256    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.6490   -3.2656    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3510   -4.8256    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3510   -3.2656    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.0000   -2.4856    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   15.7020   -5.6056    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   10.2980   -2.4856    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    8.9470   -3.2656    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    8.9470   -4.8256    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   10.2980   -5.6056    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    7.5960   -5.6056    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+    7.5960   -4.0456    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+  4  5  2  0  0  0  0
+  5  6  1  0  0  0  0
+  6  3  2  0  0  0  0
+  4  7  1  0  0  0  0
+  3  8  1  0  0  0  0
+  8  9  1  0  0  0  0
+  9 10  1  0  0  0  0
+ 10 11  1  0  0  0  0
+ 11  2  1  0  0  0  0
+ 10 12  1  0  0  0  0
+ 10 13  1  0  0  0  0
+M  ISO  1   7  15
+M  ISO  1  12   2
+M  ISO  1  13   2
+M  END`;
+
+// Same structure with only the first isotope record.
+const ISOTOPES_MOL_KETCHER_STRIPPED = ISOTOPES_MOL
+  .replace('M  ISO  1  12   2\n', '')
+  .replace('M  ISO  1  13   2\n', '');
+
+// Same structure without isotope records.
+const ISOTOPES_MOL_NO_ISO = ISOTOPES_MOL
+  .replace(/M  ISO.*\n/g, '');
+
+// V2000 structure without isotopes.
+const BENZENE_MOL = `
+  Ketcher 0101241530 2D 1   1.00000     0.00000     0
+
+  6  6  0  0  0  0            999 V2000
+    1.0000    0.0000    0.0000 C   0  0
+    0.5000    0.8660    0.0000 C   0  0
+   -0.5000    0.8660    0.0000 C   0  0
+   -1.0000    0.0000    0.0000 C   0  0
+   -0.5000   -0.8660    0.0000 C   0  0
+    0.5000   -0.8660    0.0000 C   0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  2  0  0  0  0
+  4  5  1  0  0  0  0
+  5  6  2  0  0  0  0
+  6  1  1  0  0  0  0
+M  END`;
+
+describe('getCounts', () => {
+  it('returns correct atom/bond counts for ISOTOPES_MOL', () => {
+    const c = getCounts(ISOTOPES_MOL)!;
+    expect(c.atomCount).toBe(13);
+    expect(c.bondCount).toBe(14);
+  });
+
+  it('returns correct atom/bond counts for BENZENE_MOL', () => {
+    const c = getCounts(BENZENE_MOL)!;
+    expect(c.atomCount).toBe(6);
+    expect(c.bondCount).toBe(6);
+  });
+
+  it('returns null for empty string', () => {
+    expect(getCounts('')).toBeNull();
+  });
+
+  it('returns null for a string with no V2000', () => {
+    expect(getCounts('hello world')).toBeNull();
+  });
+});
+
+describe('getAtomElements', () => {
+  it('returns 13 elements for ISOTOPES_MOL', () => {
+    const els = getAtomElements(ISOTOPES_MOL);
+    expect(els.length).toBe(13);
+    expect(els[6]).toBe('N');
+    expect(els[11]).toBe('H');
+    expect(els[12]).toBe('H');
+  });
+});
+
+describe('getIsoEntries', () => {
+  it('reads all three separate M  ISO lines', () => {
+    const entries = getIsoEntries(ISOTOPES_MOL);
+    expect(entries.length).toBe(3);
+
+    const n15 = entries.find(e => e.atomIndex === 7);
+    expect(n15).toBeDefined();
+    expect(n15!.isotope).toBe(15);
+    expect(n15!.element).toBe('N');
+
+    const d12 = entries.find(e => e.atomIndex === 12);
+    expect(d12).toBeDefined();
+    expect(d12!.isotope).toBe(2);
+    expect(d12!.element).toBe('H');
+
+    const d13 = entries.find(e => e.atomIndex === 13);
+    expect(d13).toBeDefined();
+    expect(d13!.isotope).toBe(2);
+  });
+
+  it('returns empty array for molfile without M  ISO', () => {
+    expect(getIsoEntries(BENZENE_MOL).length).toBe(0);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(getIsoEntries('').length).toBe(0);
+  });
+
+  it('handles single consolidated M  ISO line with multiple entries', () => {
+    const consolidated = consolidateIsoLines(ISOTOPES_MOL);
+    const entries = getIsoEntries(consolidated);
+    expect(entries.length).toBe(3);
+  });
+});
+
+describe('formatIsoLines', () => {
+  it('produces a single line for ≤8 entries', () => {
+    const lines = formatIsoLines([
+      { atomIndex: 7, isotope: 15 },
+      { atomIndex: 12, isotope: 2 },
+      { atomIndex: 13, isotope: 2 },
+    ]);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toBe('M  ISO  3   7  15  12   2  13   2');
+  });
+
+  it('splits into multiple lines for >8 entries', () => {
+    const entries = Array.from({ length: 9 }, (_, i) => ({ atomIndex: i + 1, isotope: i + 100 }));
+    const lines = formatIsoLines(entries);
+    expect(lines.length).toBe(2);
+    expect(lines[0].startsWith('M  ISO  8')).toBeTrue();
+    expect(lines[1].startsWith('M  ISO  1')).toBeTrue();
+  });
+
+  it('returns empty array for no entries', () => {
+    expect(formatIsoLines([])).toEqual([]);
+  });
+});
+
+describe('consolidateIsoLines', () => {
+  it('merges three separate single-entry lines into one line', () => {
+    const result = consolidateIsoLines(ISOTOPES_MOL);
+    const isoLines = result.split('\n').filter(l => l.startsWith('M  ISO'));
+    expect(isoLines.length).toBe(1);
+    expect(isoLines[0]).toContain('7  15');
+    expect(isoLines[0]).toContain('12   2');
+    expect(isoLines[0]).toContain('13   2');
+  });
+
+  it('preserves all other molfile content', () => {
+    const result = consolidateIsoLines(ISOTOPES_MOL);
+    expect(result).toContain('M  END');
+    expect(result).toContain('V2000');
+    expect(getAtomElements(result).length).toBe(13);
+  });
+
+  it('is a no-op when there are no M  ISO lines', () => {
+    expect(consolidateIsoLines(BENZENE_MOL)).toBe(BENZENE_MOL);
+  });
+
+  it('is a no-op for an already-consolidated single M  ISO line', () => {
+    const oneLine = ISOTOPES_MOL_NO_ISO.replace(
+      'M  END',
+      'M  ISO  3   7  15  12   2  13   2\nM  END',
+    );
+    const result = consolidateIsoLines(oneLine);
+    const isoLines = result.split('\n').filter(l => l.startsWith('M  ISO'));
+    expect(isoLines.length).toBe(1);
+  });
+
+  it('sorts entries by atom index', () => {
+    const reversed = ISOTOPES_MOL_NO_ISO.replace(
+      'M  END',
+      'M  ISO  1  13   2\nM  ISO  1   7  15\nM  ISO  1  12   2\nM  END',
+    );
+    const result = consolidateIsoLines(reversed);
+    expect(result).toContain('M  ISO  3   7  15  12   2  13   2');
+  });
+});
+
+describe('hasSameStructureLayout', () => {
+  it('returns true when the only difference is M  ISO entries', () => {
+    expect(hasSameStructureLayout(ISOTOPES_MOL, ISOTOPES_MOL_NO_ISO)).toBeTrue();
+  });
+
+  it('returns true for identical molfiles', () => {
+    expect(hasSameStructureLayout(ISOTOPES_MOL, ISOTOPES_MOL)).toBeTrue();
+  });
+
+  it('returns false when atom count differs', () => {
+    expect(hasSameStructureLayout(ISOTOPES_MOL, BENZENE_MOL)).toBeFalse();
+  });
+
+  it('returns false for empty string', () => {
+    expect(hasSameStructureLayout(ISOTOPES_MOL, '')).toBeFalse();
+  });
+});
+
+describe('restoreMissingIsoEntries', () => {
+  it('restores all three ISO entries when Ketcher stripped two (first-block-only bug)', () => {
+    const trusted = ISOTOPES_MOL;
+    const raw = ISOTOPES_MOL_KETCHER_STRIPPED;
+
+    const repaired = restoreMissingIsoEntries(trusted, raw);
+    const entries = getIsoEntries(repaired);
+    expect(entries.length).toBe(3);
+    expect(entries.find(e => e.atomIndex === 7)?.isotope).toBe(15);
+    expect(entries.find(e => e.atomIndex === 12)?.isotope).toBe(2);
+    expect(entries.find(e => e.atomIndex === 13)?.isotope).toBe(2);
+  });
+
+  it('restores all ISO entries when server returned molfile with no M  ISO', () => {
+    const repaired = restoreMissingIsoEntries(ISOTOPES_MOL, ISOTOPES_MOL_NO_ISO);
+    const entries = getIsoEntries(repaired);
+    expect(entries.length).toBe(3);
+  });
+
+  it('returns rawMolfile unchanged when trustedMolfile has no ISO entries', () => {
+    const result = restoreMissingIsoEntries(BENZENE_MOL, ISOTOPES_MOL_NO_ISO);
+    expect(result).toBe(ISOTOPES_MOL_NO_ISO);
+  });
+
+  it('returns rawMolfile unchanged when all trusted entries are already present', () => {
+    const result = restoreMissingIsoEntries(ISOTOPES_MOL, ISOTOPES_MOL);
+    expect(getIsoEntries(result).length).toBe(3);
+  });
+
+  it('returns rawMolfile unchanged when structure layout differs (user structural edit)', () => {
+    const result = restoreMissingIsoEntries(ISOTOPES_MOL, BENZENE_MOL);
+    expect(result).toBe(BENZENE_MOL);
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(restoreMissingIsoEntries(ISOTOPES_MOL, '')).toBe('');
+  });
+});
+
+describe('Scenario 1 regression: validation does not strip isotopes', () => {
+  it('consolidateIsoLines then restoreMissingIsoEntries round-trips all 3 isotopes', () => {
+    const consolidated = consolidateIsoLines(ISOTOPES_MOL);
+    const isoAfterConsolidate = getIsoEntries(consolidated);
+    expect(isoAfterConsolidate.length).toBe(3);
+
+    // Simulate Ketcher returning only the first isotope record.
+    const ketcherOutput = consolidated
+      .split('\n')
+      .filter(l => !l.startsWith('M  ISO'))
+      .join('\n')
+      .replace('M  END', 'M  ISO  1   7  15\nM  END'); // only N-15
+
+    const repaired = restoreMissingIsoEntries(consolidated, ketcherOutput);
+    const entriesAfterRepair = getIsoEntries(repaired);
+    expect(entriesAfterRepair.length).toBe(3);
+    expect(entriesAfterRepair.find(e => e.atomIndex === 12)?.isotope).toBe(2);
+    expect(entriesAfterRepair.find(e => e.atomIndex === 13)?.isotope).toBe(2);
+  });
+});
+
+describe('Scenario 2 regression: newly added isotope survives validate', () => {
+  // Pb structure without an isotope record.
+  const PB_MOL_NO_ISO = `
+  Ketcher 0609262305 2D 1   1.00000     0.00000     0
+
+ 13 14  0  0  0  0            999 V2000
+   25.8950   -9.2560    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   24.5440   -8.4760    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   24.5440   -6.9160    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   27.2460   -8.4760    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   27.2460   -6.9160    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   25.8950   -6.1360    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   28.5970   -9.2560    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   23.1930   -6.1360    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   21.8420   -6.9160    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   21.8420   -8.4760    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   23.1930   -9.2560    0.0000 Pb  0  0  0  0  0  0  0  0  0  0  0  0
+   20.4910   -9.2560    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+   20.4910   -7.6960    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+  4  5  2  0  0  0  0
+  5  6  1  0  0  0  0
+  6  3  2  0  0  0  0
+  4  7  1  0  0  0  0
+  3  8  1  0  0  0  0
+  8  9  1  0  0  0  0
+  9 10  1  0  0  0  0
+ 10 11  1  0  0  0  0
+ 11  2  1  0  0  0  0
+ 10 12  1  0  0  0  0
+ 10 13  1  0  0  0  0
+M  END`;
+
+  // Same structure with Pb-204 on atom 11.
+  const PB204_MOL = PB_MOL_NO_ISO.replace('M  END', 'M  ISO  1  11 204\nM  END');
+
+  it('restores Pb-204 from trusted when Ketcher strips M  ISO', () => {
+    const repaired = restoreMissingIsoEntries(PB204_MOL, PB_MOL_NO_ISO);
+    const entries = getIsoEntries(repaired);
+    expect(entries.length).toBe(1);
+    expect(entries[0].atomIndex).toBe(11);
+    expect(entries[0].isotope).toBe(204);
+    expect(entries[0].element).toBe('Pb');
+  });
+
+  it('does NOT restore when user intentionally removed isotope (layout unchanged)', () => {
+    // This helper restores missing records when layout is unchanged.
+    // Explicit editor isotope changes bypass this helper.
+    const repaired = restoreMissingIsoEntries(PB204_MOL, PB_MOL_NO_ISO);
+    expect(getIsoEntries(repaired).length).toBe(1);
+  });
+});
+
+describe('Toggle regression: JSDraw→Ketcher does not strip isotopes', () => {
+  it('trusted baseline survives an interpretStructure round-trip that strips ISO', () => {
+    const lastTrustedIsoMolfile = ISOTOPES_MOL;
+
+    // Simulate Ketcher returning a molfile without isotope records.
+    const ketcherStrippedOutput = ISOTOPES_MOL_NO_ISO;
+
+    const repaired = restoreMissingIsoEntries(lastTrustedIsoMolfile, ketcherStrippedOutput);
+    expect(getIsoEntries(repaired).length).toBe(3);
+  });
+});

--- a/src/app/core/structure-editor/molfile-isotope.util.ts
+++ b/src/app/core/structure-editor/molfile-isotope.util.ts
@@ -1,0 +1,175 @@
+// Helpers for reading and preserving V2000 M  ISO records.
+
+export interface MolfileIsoEntry {
+  atomIndex: number; // 1-based atom index as used in the molfile
+  isotope:   number; // absolute mass number
+  element:   string; // element symbol from the atom block
+}
+
+export interface MolfileCounts {
+  lineIndex:  number; // 0-based index of the counts line in the split-line array
+  atomCount:  number;
+  bondCount:  number;
+}
+
+export function getCounts(molfile: string): MolfileCounts | null {
+  if (!molfile) { return null; }
+
+  const lines     = molfile.split('\n');
+  const lineIndex = lines.findIndex(l => l.includes('V2000'));
+  if (lineIndex === -1) { return null; }
+
+  const parts     = lines[lineIndex].trim().split(/\s+/);
+  const atomCount = parseInt(parts[0], 10);
+  const bondCount = parseInt(parts[1], 10);
+  if (isNaN(atomCount) || isNaN(bondCount) || atomCount <= 0 || bondCount < 0) {
+    return null;
+  }
+  return { lineIndex, atomCount, bondCount };
+}
+
+export function getAtomElements(molfile: string): string[] {
+  const counts = getCounts(molfile);
+  if (!counts) { return []; }
+
+  return molfile.split('\n')
+    .slice(counts.lineIndex + 1, counts.lineIndex + 1 + counts.atomCount)
+    .map(line => line.trim().split(/\s+/)[3])
+    .filter(Boolean);
+}
+
+export function getBondLayout(molfile: string): string[] {
+  const counts = getCounts(molfile);
+  if (!counts) { return []; }
+
+  return molfile.split('\n')
+    .slice(
+      counts.lineIndex + 1 + counts.atomCount,
+      counts.lineIndex + 1 + counts.atomCount + counts.bondCount,
+    )
+    .map(line => {
+      const p = line.trim().split(/\s+/);
+      const a = parseInt(p[0], 10);
+      const b = parseInt(p[1], 10);
+      return `${Math.min(a, b)}-${Math.max(a, b)}-${p[2]}`;
+    })
+    .sort();
+}
+
+/** Checks atom order and bond topology without comparing isotope properties. */
+export function hasSameStructureLayout(trusted: string, incoming: string): boolean {
+  const te = getAtomElements(trusted);
+  const ie = getAtomElements(incoming);
+  if (te.length === 0 || te.length !== ie.length) { return false; }
+  if (!te.every((el, i) => el === ie[i])) { return false; }
+
+  const tb = getBondLayout(trusted);
+  const ib = getBondLayout(incoming);
+  return tb.length === ib.length && tb.every((b, i) => b === ib[i]);
+}
+
+/** Reads isotope entries from all M  ISO lines. */
+export function getIsoEntries(molfile: string): MolfileIsoEntry[] {
+  if (!molfile) { return []; }
+
+  const atomElements = getAtomElements(molfile);
+  const entries: MolfileIsoEntry[] = [];
+
+  for (const line of molfile.split('\n')) {
+    if (!line.startsWith('M  ISO')) { continue; }
+
+    const parts = line.trim().split(/\s+/);
+    const count = parseInt(parts[2], 10);
+    if (isNaN(count)) { continue; }
+
+    for (let i = 0; i < count; i++) {
+      const atomIndex = parseInt(parts[3 + i * 2], 10);
+      const isotope   = parseInt(parts[4 + i * 2], 10);
+      const element   = atomElements[atomIndex - 1];
+      if (!isNaN(atomIndex) && !isNaN(isotope) && element) {
+        entries.push({ atomIndex, isotope, element });
+      }
+    }
+  }
+
+  return entries;
+}
+
+export function formatIsoLines(entries: Array<{ atomIndex: number; isotope: number }>): string[] {
+  const lines: string[] = [];
+  for (let i = 0; i < entries.length; i += 8) {
+    const chunk = entries.slice(i, i + 8);
+    let line = `M  ISO${String(chunk.length).padStart(3)}`;
+    for (const e of chunk) {
+      line += `${String(e.atomIndex).padStart(4)}${String(e.isotope).padStart(4)}`;
+    }
+    lines.push(line);
+  }
+  return lines;
+}
+
+export function addIsoLines(
+  linesWithoutIso: string[],
+  entries: Array<{ atomIndex: number; isotope: number }>,
+): string {
+  if (entries.length === 0) { return linesWithoutIso.join('\n'); }
+  const isoLines = formatIsoLines(entries);
+  const endIdx   = linesWithoutIso.findIndex(l => l.startsWith('M  END'));
+  const result   = [...linesWithoutIso];
+  result.splice(endIdx === -1 ? result.length : endIdx, 0, ...isoLines);
+  return result.join('\n');
+}
+
+/** Combines M  ISO entries into blocks of up to eight atom/isotope pairs. */
+export function consolidateIsoLines(molfile: string): string {
+  if (!molfile || !molfile.includes('M  ISO')) { return molfile; }
+
+  const entries: Array<{ atomIndex: number; isotope: number }> = [];
+  const filteredLines: string[] = [];
+
+  for (const line of molfile.split('\n')) {
+    if (line.startsWith('M  ISO')) {
+      const parts = line.trim().split(/\s+/);
+      const count = parseInt(parts[2], 10);
+      if (isNaN(count)) { continue; }
+      for (let i = 0; i < count; i++) {
+        const atomIndex = parseInt(parts[3 + i * 2], 10);
+        const isotope   = parseInt(parts[4 + i * 2], 10);
+        if (!isNaN(atomIndex) && !isNaN(isotope)) {
+          entries.push({ atomIndex, isotope });
+        }
+      }
+    } else {
+      filteredLines.push(line);
+    }
+  }
+
+  if (entries.length === 0) { return molfile; }
+  // Keep output stable for comparisons and tests.
+  entries.sort((a, b) => a.atomIndex - b.atomIndex);
+  return addIsoLines(filteredLines, entries);
+}
+
+/**
+ * Restores isotope entries missing from editor output.
+ * A changed atom or bond layout is treated as a user edit and is not repaired.
+ */
+export function restoreMissingIsoEntries(trustedMolfile: string, rawMolfile: string): string {
+  const trustedEntries = getIsoEntries(trustedMolfile);
+  if (trustedEntries.length === 0) { return rawMolfile; }
+
+  const rawEntries     = getIsoEntries(rawMolfile);
+  const missingEntries = trustedEntries.filter(
+    t => !rawEntries.some(r => r.atomIndex === t.atomIndex),
+  );
+
+  if (missingEntries.length === 0) { return rawMolfile; }
+  if (!hasSameStructureLayout(trustedMolfile, rawMolfile)) { return rawMolfile; }
+
+  // Add missing entries and normalize the ISO blocks.
+  const withMissing = addIsoLines(
+    rawMolfile.split('\n').filter(l => !l.startsWith('M  ISO')),
+    [...rawEntries, ...missingEntries].sort((a, b) => a.atomIndex - b.atomIndex),
+  );
+  return withMissing;
+}

--- a/src/app/core/structure-editor/structure-editor-implementation.model.spec.ts
+++ b/src/app/core/structure-editor/structure-editor-implementation.model.spec.ts
@@ -1,0 +1,123 @@
+import { EditorImplementation } from './structure-editor-implementation.model';
+import { Ketcher } from './structure.editor.model';
+
+describe('EditorImplementation regressions', () => {
+  let changeHandler: (operations: Array<{ operation: string }>) => void;
+  let rawMolfile: string;
+  let getMolfileCalls: number;
+  let ketcher: Ketcher;
+
+  beforeEach(() => {
+    rawMolfile = [
+      '',
+      '  Ketcher',
+      '',
+      '  1  0  0  0  0  0            999 V2000',
+      '    0.0000    0.0000    0.0000 C   0  0',
+      'M  END',
+    ].join('\n');
+    getMolfileCalls = 0;
+    ketcher = {
+      version: '',
+      apiPath: '',
+      buildDate: '',
+      editor: {
+        subscribe: (_event: string, handler: typeof changeHandler) => {
+          changeHandler = handler;
+        },
+        event: {
+          change: {
+            handlers: [],
+          },
+        },
+      },
+      getSmiles: () => '',
+      saveSmiles: () => Promise.resolve(''),
+      getMolfile: () => {
+        getMolfileCalls++;
+        return Promise.resolve(rawMolfile);
+      },
+      setMolecule: () => undefined,
+      addFragment: () => undefined,
+      showMolfile: () => undefined,
+    };
+  });
+
+  it('does not emit or read Ketcher output for a tracked programmatic load', () => {
+    const editor = new EditorImplementation(ketcher);
+    const emitted: string[] = [];
+    editor.structureUpdated().subscribe(molfile => emitted.push(molfile));
+
+    editor.setMolecule(rawMolfile);
+    changeHandler([{ operation: 'Load canvas' }]);
+
+    expect(getMolfileCalls).toBe(0);
+    expect(emitted).toEqual([]);
+  });
+
+  it('emits the molfile for a real user edit', async () => {
+    const editor = new EditorImplementation(ketcher);
+    const emitted = new Promise<string>(resolve => {
+      editor.structureUpdated().subscribe(resolve);
+    });
+
+    changeHandler([{ operation: 'Add atom' }]);
+
+    expect(await emitted).toBe(rawMolfile);
+    expect(getMolfileCalls).toBe(1);
+  });
+
+  it('does not suppress an untracked user Load canvas operation', async () => {
+    const editor = new EditorImplementation(ketcher);
+    const emitted = new Promise<string>(resolve => {
+      editor.structureUpdated().subscribe(resolve);
+    });
+
+    changeHandler([{ operation: 'Load canvas' }]);
+
+    expect(await emitted).toBe(rawMolfile);
+    expect(getMolfileCalls).toBe(1);
+  });
+
+  it('accepts explicit isotope removal without restoring the old isotope', async () => {
+    const isotopeMolfile = rawMolfile.replace('M  END', 'M  ISO  1   1  13\nM  END');
+    const editor = new EditorImplementation(ketcher);
+    const emitted = new Promise<string>(resolve => {
+      editor.structureUpdated().subscribe(resolve);
+    });
+    editor.setMolecule(isotopeMolfile);
+    changeHandler([{ operation: 'Load canvas' }]);
+
+    changeHandler([{
+      operation: 'Set atom attribute',
+      attribute: 'isotope',
+      from: 13,
+      to: 0,
+    } as any]);
+
+    expect(await emitted).not.toContain('M  ISO');
+  });
+
+  it('accepts an explicit isotope mass change as the new trusted value', async () => {
+    const isotope204 = rawMolfile.replace('M  END', 'M  ISO  1   1 204\nM  END');
+    const isotope206 = rawMolfile.replace('M  END', 'M  ISO  1   1 206\nM  END');
+    const editor = new EditorImplementation(ketcher);
+    const emitted = new Promise<string>(resolve => {
+      editor.structureUpdated().subscribe(resolve);
+    });
+    editor.setMolecule(isotope204);
+    changeHandler([{ operation: 'Load canvas' }]);
+
+    rawMolfile = isotope206;
+    changeHandler([{
+      operation: 'Set atom attribute',
+      attribute: 'isotope',
+      from: 204,
+      to: 206,
+    } as any]);
+
+    const result = await emitted;
+    expect(result).toContain('M  ISO  1   1 206');
+    expect(result).not.toContain('M  ISO  1   1 204');
+  });
+});

--- a/src/app/core/structure-editor/structure-editor-implementation.model.ts
+++ b/src/app/core/structure-editor/structure-editor-implementation.model.ts
@@ -1,5 +1,6 @@
 import { Editor, JSDraw, Ketcher } from './structure.editor.model';
-import { Observable, from, pipe, switchMap, take } from 'rxjs';
+import { Observable, from, take } from 'rxjs';
+import { consolidateIsoLines, restoreMissingIsoEntries, getIsoEntries, getCounts } from './molfile-isotope.util';
 
 export class EditorImplementation implements Editor {
     private ketcher?: Ketcher;
@@ -7,97 +8,82 @@ export class EditorImplementation implements Editor {
     tempMol?: string;
     firstload?: boolean;
 
+    // Last complete V2000 molfile, used to restore isotope records dropped by Ketcher.
+    private lastTrustedMolfile = '';
+
+    // Ignore change events caused by programmatic Ketcher loads.
+    private pendingProgrammaticLoads = 0;
+    private pendingProgrammaticLoadTimer: ReturnType<typeof setTimeout> | null = null;
+
     constructor(ketcher?: Ketcher, jsdraw?: JSDraw, toggledFrom?: string) {
-        
         if (toggledFrom) {
             this.ketcher = ketcher;
             this.forceKetcherUpdate(toggledFrom);
         } else {
-            this.jsdraw = jsdraw;
+            this.jsdraw  = jsdraw;
             this.ketcher = ketcher;
         }
     }
 
     forceKetcherUpdate(mfile: string): void {
-                this.jsdraw = null;
-                setTimeout(() => {
-                    const chargeLine = this.getMCharge();
-                    mfile = mfile.replace(/0.0000[ ]D[ ][ ][ ]/g, '0.0000 H   ');
+        this.jsdraw = undefined;
+        setTimeout(() => {
+            const chargeLine = this.getMCharge();
+            mfile = mfile.replace(/0.0000[ ]D[ ][ ][ ]/g, '0.0000 H   ');
 
-            if (mfile.indexOf('M  CHG') < 0) {
-                if (chargeLine !== null) {
-                    const lines = mfile.split('\n');
-                    for (let i = lines.length - 1; i >= 3; i--) {
-                        if (lines[i] === 'M  END') {
-                            const old = lines[i];
-                            lines[i] = chargeLine;
-                            lines[i + 1] = old;
-                            mfile = lines.join('\n');
-                            break;
-                        }
-                    
-                    
-                    
+            if (mfile.indexOf('M  CHG') < 0 && chargeLine != null) {
+                const lines = mfile.split('\n');
+                for (let i = lines.length - 1; i >= 3; i--) {
+                    if (lines[i] === 'M  END') {
+                        lines.splice(i, 0, chargeLine);
+                        mfile = lines.join('\n');
+                        break;
                     }
                 }
             }
             this.tempMol = this.clean(mfile);
-
-            this.ketcher.setMolecule(this.tempMol);
-                
-                }, 1);
-            
-               
+            this.setKetcherMolecule(this.tempMol);
+        }, 1);
     }
-
-    
 
     getMolfile(): Observable<any> {
         return new Observable<any>(observer => {
-        if (this.ketcher && this.ketcher != null) {
-            this.ketcher.getMolfile('v2000').then(result => {
-                observer.next(result);
+            if (this.ketcher != null) {
+                (this.ketcher.getMolfile('v2000') as Promise<string>).then(result => {
+                    observer.next(this.getSafeKetcherMolfile(result || ''));
+                });
+            } else if (this.jsdraw != null) {
+                const chargeLine = this.getMCharge();
+                let mfile = this.jsdraw.getMolfile();
+                mfile = mfile.replace(/0.0000[ ]D[ ][ ][ ]/g, '0.0000 H   ');
 
-        });
-            
-           
-        } else if (this.jsdraw && this.jsdraw != null) {
-            const chargeLine = this.getMCharge();
-            let mfile = this.jsdraw.getMolfile();
-            mfile = mfile.replace(/0.0000[ ]D[ ][ ][ ]/g, '0.0000 H   ');
-
-            if (mfile.indexOf('M  CHG') < 0) {
-                if (chargeLine !== null) {
+                if (mfile.indexOf('M  CHG') < 0 && chargeLine != null) {
                     const lines = mfile.split('\n');
                     for (let i = lines.length - 1; i >= 3; i--) {
                         if (lines[i] === 'M  END') {
-                            const old = lines[i];
-                            lines[i] = chargeLine;
-                            lines[i + 1] = old;
+                            lines.splice(i, 0, chargeLine);
                             mfile = lines.join('\n');
                             break;
                         }
                     }
                 }
-            }
-           
                 observer.next(this.clean(mfile));
-        
-        } else {
-            console.log('returning null');
-            observer.next(null);
-        }
-    });
-}
+            } else {
+                console.log('returning null');
+                observer.next(null);
+            }
+        });
+    }
 
     getSmiles(): Observable<string> {
         if (this.ketcher != null) {
-        return from(this.ketcher.getSmiles());
-        } else if (this.jsdraw != null) {
-            return new Observable<string>(observer => {
-                observer.next(this.jsdraw.getSmiles());
-            });
+            return from(this.ketcher.getSmiles());
         }
+        return new Observable<string>(observer => {
+            if (this.jsdraw != null) {
+                observer.next(this.jsdraw.getSmiles());
+            }
+        });
     }
 
     private clean(molfile: string): string {
@@ -105,48 +91,67 @@ export class EditorImplementation implements Editor {
             .replace(/\n/g, '|_|')
             .replace(/[@][|][_][|]/g, '')
             .replace(/[|][_][|]/g, '\n');
-      
-        // This corrects a rather silly bug
-        // where JSDraw repeats SMT groups for polymers,
-        // causing a lot of unforunate side effects
 
+        // Remove duplicate polymer SMT groups written by JSDraw.
         if (molfile.indexOf('M  STY') >= 0) {
             const lines = molfile.split('\n');
             let dupCount = 0;
-            let tset = {};
+            const tset: Record<string, number> = {};
             Array.from(lines)
-                 .filter(l=>l.indexOf('M  SMT')>=0)
-                 .map(l=>l.substring(0,10))
-                 .map(l=>{
-                    if(tset[l]){
-                       dupCount++;
-                    }
-                    tset[l]=1;
+                 .filter(l => l.indexOf('M  SMT') >= 0)
+                 .map(l => l.substring(0, 10))
+                 .forEach(l => {
+                     if (tset[l]) { dupCount++; }
+                     tset[l] = 1;
                  });
-           if(dupCount>0){
-               // This just replaces each SMT line with the STY group number defined before it
-               // The '!#!' and '@' symbols are used as temporary "protecting groups"
-               molfile = molfile.replace(/@/g,'!#!')
-                            .replace(/STY/g,'@')
-                            .replace(/(M[ ][ ]@[ ][ ]1)([ ]*[0-9]*)([^@]*)SMT([ ]*[0-9]*)/g,'$1$2$3SMT$2')
-                            .replace(/@/g,'STY')
-                            .replace(/!#!/g,'@');
-           }
+            if (dupCount > 0) {
+                molfile = molfile.replace(/@/g, '!#!')
+                             .replace(/STY/g, '@')
+                             .replace(/(M[ ][ ]@[ ][ ]1)([ ]*[0-9]*)([^@]*)SMT([ ]*[0-9]*)/g, '$1$2$3SMT$2')
+                             .replace(/@/g, 'STY')
+                             .replace(/!#!/g, '@');
+            }
         }
         return molfile;
     }
 
     setMolecule(molfile: string): void {
-        if (this.ketcher && this.ketcher != null) {
-            this.ketcher.setMolecule(molfile);
-            this.ketcher.setMolecule(molfile);
-        } else if (this.jsdraw && this.jsdraw != null) {
-            // from simple tests, this should push the current molecule down
-            // on the undo stack.
+        if (this.ketcher != null) {
+            this.setKetcherMolecule(molfile);
+        } else if (this.jsdraw != null) {
+            // Keep the previous molecule on the undo stack.
             this.jsdraw.pushundo();
             this.jsdraw.options.data = molfile;
             this.jsdraw.setMolfile(molfile);
         }
+    }
+
+    // Consolidate isotope records and use V3000 for Ketcher display when supported.
+    private setKetcherMolecule(molfile: string): void {
+        const consolidated   = consolidateIsoLines(molfile || '');
+        const displayMolfile = this.toV3000DisplayMolfile(consolidated) ?? consolidated;
+        this.lastTrustedMolfile = consolidated;
+        this.incrementPendingLoads();
+        (this.ketcher as Ketcher).setMolecule(displayMolfile);
+    }
+
+    // Restore missing isotope records only when the atom and bond layout is unchanged.
+    private getSafeKetcherMolfile(rawMolfile: string): string {
+        const consolidated = consolidateIsoLines(rawMolfile || '');
+        const repaired     = restoreMissingIsoEntries(this.lastTrustedMolfile, consolidated);
+        this.lastTrustedMolfile = repaired;
+        return repaired;
+    }
+
+    private incrementPendingLoads(): void {
+        this.pendingProgrammaticLoads++;
+        if (this.pendingProgrammaticLoadTimer !== null) {
+            clearTimeout(this.pendingProgrammaticLoadTimer);
+        }
+        this.pendingProgrammaticLoadTimer = setTimeout(() => {
+            this.pendingProgrammaticLoads = 0;
+            this.pendingProgrammaticLoadTimer = null;
+        }, 2000);
     }
 
     structureUpdated(): Observable<string> {
@@ -158,81 +163,186 @@ export class EditorImplementation implements Editor {
                     });
                 };
             } else if (this.ketcher != null) {
-              this.ketcher.editor.subscribe('change',  operations => {
-                    if(!(operations.length == 1 && operations[0].operation == 'Load canvas')){
-                        this.ketcher.getMolfile('v2000').then(result => {
-                            observer.next(result);
-                        });
-                    } else {
-                        this.getMolfile().pipe(take(1)).subscribe(result => {
-                            observer.next(result);
-                        });
+                const ketcher = this.ketcher;
+                const handler = (operations: Array<{ operation: string }>) => {
+                    const isLoadCanvas = operations.some(
+                        op => op.operation === 'Load canvas',
+                    );
+                    const hasExplicitIsotopeEdit = operations.some(
+                        (op: { operation: string; attribute?: string }) =>
+                            op.operation === 'Set atom attribute' && op.attribute === 'isotope',
+                    );
+
+                    if (isLoadCanvas && this.pendingProgrammaticLoads > 0) {
+                        this.pendingProgrammaticLoads--;
+                        return;
                     }
 
+                    // Untracked loads are user imports and must update the form.
+                    (ketcher.getMolfile('v2000') as Promise<string>).then(result => {
+                        const rawMolfile = consolidateIsoLines(result || '');
+                        if (hasExplicitIsotopeEdit) {
+                            this.lastTrustedMolfile = rawMolfile;
+                            observer.next(rawMolfile);
+                        } else {
+                            observer.next(this.getSafeKetcherMolfile(rawMolfile));
+                        }
+                    });
+                };
 
-                 });
+                ketcher.editor.subscribe('change', handler);
 
-            }
-            else {
-                observer.next(null);
+                return () => {
+                    // Ketcher does not expose the subscription token here, so remove
+                    // the matching internal handler when possible.
+                    try {
+                        const handlers: Array<{ handler: Function; f?: Function }> =
+                            (ketcher.editor as any)?.event?.change?.handlers;
+                        if (Array.isArray(handlers)) {
+                            const idx = handlers.findIndex(
+                                h => h.handler === handler || h.f === handler,
+                            );
+                            if (idx !== -1) { handlers.splice(idx, 1); }
+                        }
+                    } catch (_) { /* best-effort cleanup */ }
+
+                    if (this.pendingProgrammaticLoadTimer !== null) {
+                        clearTimeout(this.pendingProgrammaticLoadTimer);
+                        this.pendingProgrammaticLoadTimer = null;
+                        this.pendingProgrammaticLoads = 0;
+                    }
+                };
             }
         });
     }
 
-    getMCharge(): string {
-        if (this.jsdraw != null) {
-            const xml = this.jsdraw.getXml();
+    // V3000 is used only for Ketcher display. V2000 remains the saved format.
+    // Unsupported CTfile records fall back to consolidated V2000.
+    private toV3000DisplayMolfile(molfile: string): string | null {
+        const isoEntries = getIsoEntries(molfile);
+        if (isoEntries.length === 0) { return null; }
 
-            let aai = 1;
+        const counts = getCounts(molfile);
+        if (!counts) { return null; }
 
-            const parser = new DOMParser();
-            const xmlDoc = parser.parseFromString(xml, 'text/xml');
-
-            const charges = Array.from(xmlDoc.getElementsByTagName('a'))
-                .filter(element => element.hasAttribute('i'))
-                .map(a => {
-                    const ai = a.getAttribute('i');
-                    let ac = Number(a.getAttribute('c'));
-                    if (typeof ac === 'undefined') {
-                        ac = 0;
-                    }
-                    const o: any = {
-                        i: (aai++),
-                        c: (ac - 0)
-                    };
-                    o.toString = () => {
-                        return this.leftPad(o.i + '', 4) + this.leftPad(o.c + '', 4);
-                    };
-                    return o;
-                })
-                .filter(a => {
-                    return a.c !== 0;
-                });
-
-            if (charges.length > 0) {
-                return charges.reduce((arr, item, idx) => {
-                        return idx % 8 === 0
-                        ? [...arr, [item]]
-                        : [...arr.slice(0, -1), [...arr.slice(-1)[0], item]];
-                    }, [])
-                    .map(c => {
-                        return 'M  CHG' + this.leftPad(c.length + '', 3) +
-                        c.map(ic => ic.toString()).join('');
-                    });
+        // Other M records may contain features this conversion does not support.
+        const lines = molfile.split('\n');
+        for (const line of lines) {
+            if (line.startsWith('M  ') &&
+                !line.startsWith('M  ISO') &&
+                !line.startsWith('M  CHG') &&
+                line.trim() !== 'M  END') {
+                return null;
             }
         }
-        return null;
-    }
 
-    private rep(v: string, n: number) {
-        let t = '';
-        for (let i = 0; i < n; i++) {
-            t = t + v;
+        const atomLines = lines.slice(counts.lineIndex + 1, counts.lineIndex + 1 + counts.atomCount);
+        const bondLines = lines.slice(
+            counts.lineIndex + 1 + counts.atomCount,
+            counts.lineIndex + 1 + counts.atomCount + counts.bondCount,
+        );
+
+        const atomParts = atomLines.map(l => l.trim().split(/\s+/));
+        const bondParts = bondLines.map(l => l.trim().split(/\s+/));
+        if (atomParts.some(p => !p[3]) || bondParts.some(p => p.length < 3)) {
+            return null;
         }
-        return t;
+
+        // JSDraw may omit one of the three standard header lines.
+        const header = lines.slice(0, counts.lineIndex);
+        while (header.length < 3) { header.push(''); }
+
+        const isoByAtom    = new Map(isoEntries.map(e => [e.atomIndex, e.isotope]));
+        const chargeByAtom = this.getChargeByAtomIndex(molfile);
+        const stereoCfg: Record<number, number> = { 1: 1, 4: 2, 6: 3 };
+
+        const v3000Atoms = atomParts.map((p, i) => {
+            const atomIdx = i + 1;
+            const props: string[] = [];
+            const iso    = isoByAtom.get(atomIdx);
+            const charge = chargeByAtom.get(atomIdx);
+            if (iso    != null) { props.push(`MASS=${iso}`); }
+            if (charge != null) { props.push(`CHG=${charge}`); }
+            return `M  V30 ${atomIdx} ${p[3]} ${p[0]} ${p[1]} ${p[2]} 0`
+                + (props.length ? ' ' + props.join(' ') : '');
+        });
+
+        const v3000Bonds = bondParts.map((p, i) => {
+            const bondType = parseInt(p[2], 10);
+            const cfg      = bondType === 1 ? stereoCfg[parseInt(p[3] || '0', 10)] : undefined;
+            return `M  V30 ${i + 1} ${p[2]} ${p[0]} ${p[1]}`
+                + (cfg != null ? ` CFG=${cfg}` : '');
+        });
+
+        return [
+            ...header,
+            `  0  0  0  0  0  0            999 V3000`,
+            'M  V30 BEGIN CTAB',
+            `M  V30 COUNTS ${counts.atomCount} ${counts.bondCount} 0 0 0`,
+            'M  V30 BEGIN ATOM',
+            ...v3000Atoms,
+            'M  V30 END ATOM',
+            'M  V30 BEGIN BOND',
+            ...v3000Bonds,
+            'M  V30 END BOND',
+            'M  V30 END CTAB',
+            'M  END',
+        ].join('\n');
     }
 
-    private leftPad (v: string, p: number) {
-        return this.rep(' ', p - v.length) + v;
+    private getChargeByAtomIndex(molfile: string): Map<number, number> {
+        const result = new Map<number, number>();
+        if (!molfile) { return result; }
+        for (const line of molfile.split('\n')) {
+            if (!line.startsWith('M  CHG')) { continue; }
+            const parts = line.trim().split(/\s+/);
+            const count = parseInt(parts[2], 10);
+            if (isNaN(count)) { continue; }
+            for (let i = 0; i < count; i++) {
+                const atomIndex = parseInt(parts[3 + i * 2], 10);
+                const charge    = parseInt(parts[4 + i * 2], 10);
+                if (!isNaN(atomIndex) && !isNaN(charge)) {
+                    result.set(atomIndex, charge);
+                }
+            }
+        }
+        return result;
+    }
+
+    getMCharge(): string | null {
+        if (this.jsdraw == null) { return null; }
+
+        const xml    = this.jsdraw.getXml();
+        let   aai    = 1;
+        const parser = new DOMParser();
+        const xmlDoc = parser.parseFromString(xml, 'text/xml');
+
+        interface ChargeEntry { i: number; c: number; toString(): string; }
+        const charges: ChargeEntry[] = Array.from(xmlDoc.getElementsByTagName('a'))
+            .filter(el => el.hasAttribute('i'))
+            .map(a => {
+                const ac = Number(a.getAttribute('c')) || 0;
+                const entry: ChargeEntry = {
+                    i: aai++,
+                    c: ac,
+                    toString() {
+                        return String(this.i).padStart(4) + String(this.c).padStart(4);
+                    },
+                };
+                return entry;
+            })
+            .filter(a => a.c !== 0);
+
+        if (charges.length === 0) { return null; }
+
+        const chunkLines: string[] = [];
+        for (let i = 0; i < charges.length; i += 8) {
+            const chunk = charges.slice(i, i + 8);
+            chunkLines.push(
+                'M  CHG' + String(chunk.length).padStart(3)
+                + chunk.map(ic => ic.toString()).join(''),
+            );
+        }
+        return chunkLines.join('\n');
     }
 }

--- a/src/app/core/structure-editor/structure-editor.component.spec.ts
+++ b/src/app/core/structure-editor/structure-editor.component.spec.ts
@@ -1,4 +1,9 @@
-import { resolveStructureEditorPreference } from './structure-editor.component';
+import { of } from 'rxjs';
+import { EditorImplementation } from './structure-editor-implementation.model';
+import {
+  resolveStructureEditorPreference,
+  StructureEditorComponent,
+} from './structure-editor.component';
 
 /*import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { EditorImplementation } from './structure-editor-implementation.model';
@@ -20,6 +25,79 @@ describe('StructureEditorComponent', () => {
   it('does not restore a disabled editor', () => {
     expect(resolveStructureEditorPreference('jsdraw', 'jsdraw', false, true)).toBe('ketcher');
     expect(resolveStructureEditorPreference('ketcher', 'ketcher', true, false)).toBe('jsdraw');
+  });
+
+  it('loads the current JSDraw molfile after Ketcher is visible', () => {
+    const component = Object.create(StructureEditorComponent.prototype) as StructureEditorComponent;
+    const currentMolfile = 'blank JSDraw molfile';
+    const destinationEditor = {
+      setMolecule: jasmine.createSpy('setMolecule'),
+    };
+    const sourceEditor = {
+      getMolfile: () => of(currentMolfile),
+    };
+
+    component.structureEditor = 'jsdraw';
+    component.editor = sourceEditor as any;
+    component.ketcherLoaded = true;
+    (component as any).ketcher = {};
+    (component as any).jsdraw = { activated: true };
+    component.editorOnLoad = { emit: jasmine.createSpy('editorOnLoad') } as any;
+    component.editorSwitched = { emit: jasmine.createSpy('editorSwitched') } as any;
+    spyOn(component, 'getSketcher').and.returnValue((component as any).jsdraw);
+    spyOn(EditorImplementation.prototype, 'setMolecule').and.callFake(
+      destinationEditor.setMolecule,
+    );
+    spyOn(document, 'getElementById').and.returnValue({ style: {} } as HTMLElement);
+    const animationFrame = spyOn(window, 'requestAnimationFrame').and.callFake(() => 1);
+
+    component.toggleEditor();
+
+    expect(component.structureEditor).toBe('ketcher');
+    expect(destinationEditor.setMolecule).not.toHaveBeenCalled();
+
+    animationFrame.calls.mostRecent().args[0](0);
+
+    expect(destinationEditor.setMolecule).toHaveBeenCalledWith(currentMolfile);
+    expect(component.editorOnLoad.emit).toHaveBeenCalled();
+  });
+
+  it('loads and activates JSDraw after it is visible', () => {
+    const component = Object.create(StructureEditorComponent.prototype) as StructureEditorComponent;
+    const currentMolfile = 'Ketcher molfile';
+    const normalizedMolfile = 'normalized JSDraw molfile';
+    const destinationEditor = {
+      setMolecule: jasmine.createSpy('setMolecule'),
+    };
+
+    component.structureEditor = 'ketcher';
+    component.editor = { getMolfile: () => of(currentMolfile) } as any;
+    (component as any).jsdraw = { activated: false };
+    (component as any).structureService = {
+      interpretStructure: jasmine.createSpy('interpretStructure').and.returnValue(of({
+        structure: { molfile: normalizedMolfile },
+      })),
+    };
+    component.editorOnLoad = { emit: jasmine.createSpy('editorOnLoad') } as any;
+    component.editorSwitched = { emit: jasmine.createSpy('editorSwitched') } as any;
+    spyOn(component, 'getSketcher').and.returnValue((component as any).jsdraw);
+    spyOn(EditorImplementation.prototype, 'setMolecule').and.callFake(
+      destinationEditor.setMolecule,
+    );
+    spyOn(document, 'getElementById').and.returnValue({ style: {} } as HTMLElement);
+    const animationFrame = spyOn(window, 'requestAnimationFrame').and.callFake(() => 1);
+
+    component.toggleEditor();
+
+    expect(component.structureEditor).toBe('jsdraw');
+    expect((component as any).jsdraw.activated).toBe(false);
+    expect(destinationEditor.setMolecule).not.toHaveBeenCalled();
+
+    animationFrame.calls.mostRecent().args[0](0);
+
+    expect(destinationEditor.setMolecule).toHaveBeenCalledWith(normalizedMolfile);
+    expect((component as any).jsdraw.activated).toBe(true);
+    expect(component.editorOnLoad.emit).toHaveBeenCalled();
   });
 
 /*  let component: StructureEditorComponent;

--- a/src/app/core/structure-editor/structure-editor.component.spec.ts
+++ b/src/app/core/structure-editor/structure-editor.component.spec.ts
@@ -1,3 +1,5 @@
+import { resolveStructureEditorPreference } from './structure-editor.component';
+
 /*import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { EditorImplementation } from './structure-editor-implementation.model';
 import { StructureEditorComponent } from './structure-editor.component';
@@ -7,6 +9,19 @@ import { environment } from '../../environments/environment';
 import { JSDraw, JSDrawOptions } from 'jsdraw-wrapper';*/
 
 describe('StructureEditorComponent', () => {
+  it('restores JSDraw when it was the last enabled editor used', () => {
+    expect(resolveStructureEditorPreference('jsdraw', 'ketcher', true, true)).toBe('jsdraw');
+  });
+
+  it('restores Ketcher when it was the last enabled editor used', () => {
+    expect(resolveStructureEditorPreference('ketcher', 'jsdraw', true, true)).toBe('ketcher');
+  });
+
+  it('does not restore a disabled editor', () => {
+    expect(resolveStructureEditorPreference('jsdraw', 'jsdraw', false, true)).toBe('ketcher');
+    expect(resolveStructureEditorPreference('ketcher', 'ketcher', true, false)).toBe('jsdraw');
+  });
+
 /*  let component: StructureEditorComponent;
   let fixture: ComponentFixture<StructureEditorComponent>;
 

--- a/src/app/core/structure-editor/structure-editor.component.ts
+++ b/src/app/core/structure-editor/structure-editor.component.ts
@@ -403,21 +403,27 @@ export class StructureEditorComponent implements OnInit, AfterViewInit, OnDestro
     return skt;
   }
 
+  private afterEditorIsVisible(callback: () => void): void {
+    window.requestAnimationFrame(callback);
+  }
+
   toggleEditor() {
     if (this.structureEditor === 'ketcher') {
-      this.getSketcher().activated = true;
       this.editor.getMolfile().pipe(take(1)).subscribe(Response => {
         this.structureEditor = 'jsdraw';
         this.editor = new EditorImplementation(null, this.jsdraw);
 
         // Use the normalized molfile for JSDraw display.
         this.structureService.interpretStructure(Response).subscribe(resp => {
-          this.editorOnLoad.emit(this.editor);
           this.editorSwitched.emit(this.structureEditor);
-          this.jsdraw.setMolfile(resp.structure.molfile);
-
           sessionStorage.setItem('gsrsStructureEditor', 'jsdraw');
           document.getElementById("root").style.display = "none";
+
+          this.afterEditorIsVisible(() => {
+            this.editor.setMolecule(resp.structure.molfile);
+            this.getSketcher().activated = true;
+            this.editorOnLoad.emit(this.editor);
+          });
         });
       });
     } else {
@@ -429,19 +435,19 @@ export class StructureEditorComponent implements OnInit, AfterViewInit, OnDestro
         this.ketcherLoaded = true;
       }
 
-      this.editor.getMolfile().pipe(take(1)).subscribe(_Response => {
+      this.editor.getMolfile().pipe(take(1)).subscribe(Response => {
         this.structureEditor = 'ketcher';
         this.editor = new EditorImplementation(this.ketcher);
 
-        // editorOnLoad reloads Ketcher from the saved editor molfile.
-        this.editorOnLoad.emit(this.editor);
         this.editorSwitched.emit(this.structureEditor);
-
         sessionStorage.setItem('gsrsStructureEditor', 'ketcher');
-      });
+        document.getElementById("root").style.display = "";
 
-      this.structureEditor = 'ketcher';
-      document.getElementById("root").style.display = "";
+        this.afterEditorIsVisible(() => {
+          this.editor.setMolecule(Response);
+          this.editorOnLoad.emit(this.editor);
+        });
+      });
     }
   }
 

--- a/src/app/core/structure-editor/structure-editor.component.ts
+++ b/src/app/core/structure-editor/structure-editor.component.ts
@@ -24,6 +24,26 @@ import { MatDialog } from '@angular/material/dialog';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { JSDraw, Ketcher } from './structure.editor.model';
 
+export type StructureEditorName = 'jsdraw' | 'ketcher';
+
+export function resolveStructureEditorPreference(
+  preference: string | null,
+  defaultEditor: string,
+  enableJSDraw: boolean,
+  enableKetcher: boolean,
+): StructureEditorName {
+  if (!enableKetcher) {
+    return 'jsdraw';
+  }
+  if (!enableJSDraw) {
+    return 'ketcher';
+  }
+  if (preference === 'jsdraw' || preference === 'ketcher') {
+    return preference;
+  }
+  return defaultEditor === 'jsdraw' ? 'jsdraw' : 'ketcher';
+}
+
 @Component({
     selector: 'app-structure-editor',
     templateUrl: './structure-editor.component.html',
@@ -137,11 +157,8 @@ export class StructureEditorComponent implements OnInit, AfterViewInit, OnDestro
   }
 
   @Input() setMolecule(structure: any) {
-    if (this.structureEditor === "ketcher") {
-      this.structureService.interpretStructure(structure).subscribe(resp => {
-        this.ketcher.setMolecule(resp.structure.molfile);        
-      });
-    } else {
+    // Use the editor wrapper so Ketcher isotope handling is applied consistently.
+    if (this.editor) {
       this.editor.setMolecule(structure);
     }
   }
@@ -226,39 +243,19 @@ export class StructureEditorComponent implements OnInit, AfterViewInit, OnDestro
       window.addEventListener('drop', this.preventDrag);
       window.addEventListener('paste', this.checkPaste);
 
-      this.structureEditor = environment.structureEditor;
-      let pref = sessionStorage.getItem('gsrsStructureEditor');
-      // if JSDraw is enabled
-      if (pref && this.enableJSDraw) {
-        if (pref === 'ketcher') {
-          this.structureEditor = 'ketcher';
-        } else if (pref === 'jsdraw') {
-          this.structureEditor = 'jsdraw';
-        }
-      } else if (!this.enableJSDraw) {
-        this.structureEditor = 'ketcher';
-      }
-
       // if JSDraw is NOT Enable or is disable
       if (this.configService && this.configService.configData && this.configService.configData.disableJSDraw) {
         this.enableJSDraw = false;
-        this.structureEditor = 'ketcher';
-        if (this.firstload && this.structureEditor === 'ketcher') {
-          document.getElementById("root").style.display = "";
-          this.waitForKetcherFirstLoad();
-          this.firstload = false;
-
-        } else if (this.firstload) {
-          this.firstload = false;
-        }
       } else if (this.configService && this.configService.configData && this.configService.configData.disableKetcher) {
         this.enableKetcher = !this.configService.configData.disableKetcher;
-
-        if (!this.enableKetcher) {
-          this.structureEditor = 'jsdraw';
-        }
       }
 
+      this.structureEditor = resolveStructureEditorPreference(
+        sessionStorage.getItem('gsrsStructureEditor'),
+        environment.structureEditor,
+        this.enableJSDraw,
+        this.enableKetcher,
+      );
       this.editorSwitched.emit(this.structureEditor);
 
       if (!window['JSDraw'] && this.enableJSDraw) {
@@ -339,28 +336,18 @@ export class StructureEditorComponent implements OnInit, AfterViewInit, OnDestro
     this.overlayContainer = this.overlayContainerService.getContainerElement();
     if (isPlatformBrowser(this.platformId)) {
 
-      this.structureEditor = 'ketcher';
-
       if (this.configService && this.configService.configData && this.configService.configData.disableJSDraw) {
         this.enableJSDraw = false;
-        this.structureEditor = 'ketcher';
-
-        if (this.firstload && this.structureEditor === 'ketcher') {
-          document.getElementById("root").style.display = "";
-          this.waitForKetcherFirstLoad();
-          this.firstload = false;
-
-        } else if (this.firstload) {
-          this.firstload = false;
-        }
       } else if (this.configService && this.configService.configData && this.configService.configData.disableKetcher) {
         this.enableKetcher = !this.configService.configData.disableKetcher;
-
-        if (!this.enableKetcher) {
-          this.structureEditor = 'jsdraw';
-        }
       }
 
+      this.structureEditor = resolveStructureEditorPreference(
+        sessionStorage.getItem('gsrsStructureEditor'),
+        environment.structureEditor,
+        this.enableJSDraw,
+        this.enableKetcher,
+      );
       this.editorSwitched.emit(this.structureEditor);
 
       for (let i = 0; i < this.ketcherUrls.length; i++) {
@@ -377,9 +364,12 @@ export class StructureEditorComponent implements OnInit, AfterViewInit, OnDestro
       document.getElementsByTagName('head')[0].appendChild(node2);
 
 
-      this.getSketcher().activated = false;
+      const sketcher = this.getSketcher();
+      if (sketcher) {
+        sketcher.activated = this.structureEditor === 'jsdraw';
+      }
 
-      sessionStorage.setItem('gsrsStructureEditor', 'ketcher');
+      sessionStorage.setItem('gsrsStructureEditor', this.structureEditor);
       if (!this.ketcherLoaded) {
         this.ketcher = window['ketcher'];
         this.ketcherLoaded = true;
@@ -418,9 +408,9 @@ export class StructureEditorComponent implements OnInit, AfterViewInit, OnDestro
       this.getSketcher().activated = true;
       this.editor.getMolfile().pipe(take(1)).subscribe(Response => {
         this.structureEditor = 'jsdraw';
-        //  this.editor = new EditorImplementation(this.ketcher, this.jsdraw, 'jsdraw');
         this.editor = new EditorImplementation(null, this.jsdraw);
 
+        // Use the normalized molfile for JSDraw display.
         this.structureService.interpretStructure(Response).subscribe(resp => {
           this.editorOnLoad.emit(this.editor);
           this.editorSwitched.emit(this.structureEditor);
@@ -437,19 +427,16 @@ export class StructureEditorComponent implements OnInit, AfterViewInit, OnDestro
       if (!this.ketcherLoaded) {
         this.ketcher = window['ketcher'];
         this.ketcherLoaded = true;
-
       }
 
-      this.editor.getMolfile().pipe(take(1)).subscribe(Response => {
+      this.editor.getMolfile().pipe(take(1)).subscribe(_Response => {
         this.structureEditor = 'ketcher';
-        // this.editor = new EditorImplementation(this.ketcher, this.jsdraw, 'ketcher');
         this.editor = new EditorImplementation(this.ketcher);
-        this.structureService.interpretStructure(Response).subscribe(resp => {
-          this.editorOnLoad.emit(this.editor);
-          this.editorSwitched.emit(this.structureEditor);
-          this.ketcher.setMolecule(resp.structure.molfile);
 
-        });
+        // editorOnLoad reloads Ketcher from the saved editor molfile.
+        this.editorOnLoad.emit(this.editor);
+        this.editorSwitched.emit(this.structureEditor);
+
         sessionStorage.setItem('gsrsStructureEditor', 'ketcher');
       });
 
@@ -472,6 +459,10 @@ export class StructureEditorComponent implements OnInit, AfterViewInit, OnDestro
       this.firstload = false;
 
     } else if (this.firstload) {
+      // Keep JSDraw as the preferred editor for this session.
+      if (this.enableJSDraw) {
+        sessionStorage.setItem('gsrsStructureEditor', 'jsdraw');
+      }
       this.firstload = false;
     }
 
@@ -503,10 +494,16 @@ export class StructureEditorComponent implements OnInit, AfterViewInit, OnDestro
          });*/
         if (this.enableJSDraw) {
           this.ketcher.editor.event.change.handlers.push({
-            f: (c) => {
-              this.ketcher.getMolfile('v2000').then((result: string) => {
-                this.getSketcher().setFile(result, "mol");
-              })
+            f: (c: Array<{ operation: string }>) => {
+              const isLoadCanvas = Array.isArray(c) &&
+                c.some((op: { operation: string }) => op.operation === 'Load canvas');
+              // Mirror user edits to the JSDraw sidebar after isotope handling.
+              if (!isLoadCanvas && this.editor) {
+                this.editor.getMolfile().pipe(take(1)).subscribe((result: string) => {
+                  const jsdraw = this.getSketcher();
+                  if (jsdraw) { jsdraw.setFile(result, 'mol'); }
+                });
+              }
             }
           });
         }

--- a/src/app/core/substance-form/structure/substance-form-structure-card.component.spec.ts
+++ b/src/app/core/substance-form/structure/substance-form-structure-card.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { SubstanceFormStructureCardComponent } from './substance-form-structure-card.component';
 
@@ -21,5 +22,59 @@ describe('SubstanceFormStructureComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+});
+
+describe('SubstanceFormStructureCardComponent structure updates', () => {
+  const molfileWithoutRemovedIsotope = [
+    'test',
+    '  GSRS',
+    '',
+    '  2  1  0  0  0  0            999 V2000',
+    '    0.0000    0.0000    0.0000 Pb  0  0  0  0  0  0  0  0  0  0  0  0',
+    '    1.0000    0.0000    0.0000 N   0  3  0  0  0  0  0  0  0  0  0  0',
+    '  1  2  1  0  0  0  0',
+    'M  ISO  1   1 204',
+    'M  CHG  1   2   1',
+    'M  END',
+  ].join('\n');
+
+  function createComponentForUpdate(): {
+    component: SubstanceFormStructureCardComponent;
+    interpretStructure: jasmine.Spy;
+  } {
+    const component = Object.create(
+      SubstanceFormStructureCardComponent.prototype,
+    ) as SubstanceFormStructureCardComponent;
+    const interpretStructure = jasmine.createSpy('interpretStructure').and.returnValue(of({
+      structure: { smiles: '[204Pb][N+]' },
+    }));
+
+    component.isInitializing = false;
+    component.structure = { molfile: 'original molfile' } as any;
+    (component as any).structureService = { interpretStructure };
+    spyOn(component, 'processStructurePostResponse');
+
+    return { component, interpretStructure };
+  }
+
+  it('keeps an intentional isotope removal emitted by the editor', () => {
+    const { component, interpretStructure } = createComponentForUpdate();
+
+    component.updateStructureForm(molfileWithoutRemovedIsotope);
+
+    expect(interpretStructure).toHaveBeenCalledWith(molfileWithoutRemovedIsotope);
+    expect(component.structure.molfile).toBe(molfileWithoutRemovedIsotope);
+    expect(component.structure.molfile).not.toContain('  2  15');
+  });
+
+  it('does not mutate structure during programmatic initialization', () => {
+    const { component, interpretStructure } = createComponentForUpdate();
+    component.isInitializing = true;
+
+    component.updateStructureForm(molfileWithoutRemovedIsotope);
+
+    expect(interpretStructure).not.toHaveBeenCalled();
+    expect(component.structure.molfile).toBe('original molfile');
   });
 });

--- a/src/app/core/substance-form/structure/substance-form-structure-card.component.ts
+++ b/src/app/core/substance-form/structure/substance-form-structure-card.component.ts
@@ -35,8 +35,8 @@ export class SubstanceFormStructureCardComponent extends SubstanceFormBase imple
   userMessage: string;
   userMessageTimer: any;
   substanceType: string;
-  smiles: string;
-  mol: string;
+  smiles: string | null = null;
+  mol: string | null = null;
   features: Array<any>;
   isInitializing = true;
   private overlayContainer: HTMLElement;
@@ -63,6 +63,9 @@ export class SubstanceFormStructureCardComponent extends SubstanceFormBase imple
   ];
   showNitrosamineButton = false;
   @ViewChild(StructureEditorComponent) structureEditorComponent!: StructureEditorComponent;
+
+  // Replaced when the editor changes to avoid duplicate handlers.
+  private structureUpdatedSub: Subscription | null = null;
 
   constructor(
     private substanceFormService: SubstanceFormService,
@@ -158,20 +161,23 @@ export class SubstanceFormStructureCardComponent extends SubstanceFormBase imple
   }
 
   ngOnDestroy() {
-    this.subscriptions.forEach(subscription => {
-      subscription.unsubscribe();
-    });
+    this.subscriptions.forEach(subscription => subscription.unsubscribe());
+    this.structureUpdatedSub?.unsubscribe();
   }
 
   editorOnLoad(editor: Editor): void {
     this.loadingService.setLoading(false);
     this.structureEditor = editor;
     this.loadStructure();
-    this.structureEditor.structureUpdated().subscribe(molfile => {
+
+    // Replace the previous editor subscription when toggling editors.
+    this.structureUpdatedSub?.unsubscribe();
+    this.structureUpdatedSub = this.structureEditor.structureUpdated().subscribe(molfile => {
       this.updateStructureForm(molfile);
-      this.smiles = this.structure && this.structure.smiles || null;
-      this.mol = this.structure && this.structure.molfile || null;
+      this.smiles = (this.structure && this.structure.smiles) || null;
+      this.mol    = (this.structure && this.structure.molfile) || null;
     });
+
     this.isInitializing = false;
   }
 
@@ -193,14 +199,12 @@ export class SubstanceFormStructureCardComponent extends SubstanceFormBase imple
     if (this.structure && this.structureEditor && this.structure.molfile) {
       this.isInitializing = true;
       this.structureEditor.setMolecule(this.structure.molfile);
-      this.smiles = this.structure.smiles;
-      this.mol = this.structure.molfile;
-           // imported structures from search results require a second structure refresh to display stereochemistry and other calculated fields
-     if ( this.activatedRoute && this.activatedRoute.snapshot.queryParams && this.activatedRoute.snapshot.queryParams['importStructure']) {
-      setTimeout(()=>{
-        this.updateStructureForm(this.structure.molfile), 1000
-      });
-     }
+      this.smiles = this.structure.smiles ?? null;
+      this.mol = this.structure.molfile ?? null;
+      // Refresh imported structures after the editor finishes loading.
+      if (this.activatedRoute?.snapshot?.queryParams?.['importStructure']) {
+        setTimeout(() => { this.updateStructureForm(this.structure.molfile!); }, 1000);
+      }
       this.isInitializing = false;
     }
   }
@@ -211,15 +215,17 @@ export class SubstanceFormStructureCardComponent extends SubstanceFormBase imple
   }
 
   updateStructureForm(molfile: string): void {
-    if (!this.isInitializing) {
-      this.structure.molfile = molfile;
-      this.structureService.interpretStructure(molfile).subscribe(response => {
-        this.processStructurePostResponse(response);
-        this.structure.molfile = molfile;
-        this.smiles = response.structure.smiles;
+    if (this.isInitializing) { return; }
 
-      });
-    }
+    // The editor wrapper has already handled Ketcher isotope corrections.
+    this.structure.molfile = molfile;
+
+    this.structureService.interpretStructure(molfile).subscribe(response => {
+      this.processStructurePostResponse(response);
+      // Keep the editor molfile because server normalization may remove isotope data.
+      this.structure.molfile = molfile;
+      this.smiles = response.structure.smiles ?? null;
+    });
   }
 
    featureSort(a: any, b: any): number {
@@ -291,8 +297,8 @@ export class SubstanceFormStructureCardComponent extends SubstanceFormBase imple
       if (this.substanceType === 'polymer' ||
         this.structure['hash'] !== structurePostResponse.structure['hash'] ||
         this.structure['charge'] !== structurePostResponse.structure['charge']) {
-        this.smiles = structurePostResponse.structure.smiles;
-        this.mol = structurePostResponse.structure.molfile;
+        this.smiles = structurePostResponse.structure.smiles ?? null;
+        this.mol = structurePostResponse.structure.molfile ?? null;
         // this is sometimes overly ambitious
         Object.keys(structurePostResponse.structure).forEach(key => {
           // we don't want to do this with molfile, we want to trust the editor

--- a/src/app/core/substance-form/substance-form-validation.regression.spec.ts
+++ b/src/app/core/substance-form/substance-form-validation.regression.spec.ts
@@ -1,0 +1,112 @@
+import { of, Subject } from 'rxjs';
+import { SubstanceFormComponent } from './substance-form.component';
+import { SubstanceFormService } from './substance-form.service';
+import { ValidationResults } from './substance-form.model';
+
+describe('Substance form validation regressions', () => {
+  function createService(validationResults: ValidationResults) {
+    const substanceService = {
+      validateSubstance: jasmine.createSpy('validateSubstance').and.returnValue(of(validationResults)),
+    };
+    const service = new SubstanceFormService(
+      substanceService as any,
+      { newUUID: () => 'uuid' } as any,
+      {} as any,
+      {} as any,
+    );
+    service.loadSubstance('chemical', {
+      uuid: 'existing-substance',
+      version: '7',
+      substanceClass: 'chemical',
+      names: [],
+      codes: [],
+      references: [],
+      relationships: [],
+      properties: [],
+      structure: {
+        molfile: 'current editor molfile',
+      },
+    } as any).subscribe();
+    return { service, substanceService };
+  }
+
+  it('always calls backend validation for an unchanged existing substance', () => {
+    const { service, substanceService } = createService({
+      valid: true,
+      validationMessages: [],
+    });
+
+    service.validateSubstance().subscribe();
+
+    expect(substanceService.validateSubstance).toHaveBeenCalledTimes(1);
+    const payload = substanceService.validateSubstance.calls.mostRecent().args[0];
+    expect(payload.uuid).toBe('existing-substance');
+    expect(payload.version).toBe('7');
+    expect(payload.structure.molfile).toBe('current editor molfile');
+  });
+
+  it('passes duplicate, hash, and definitional warnings through unchanged', () => {
+    const messages = [
+      { messageType: 'WARNING', message: 'possible duplicate' },
+      { messageType: 'WARNING', message: 'definitional hash changed' },
+      { messageType: 'ERROR', message: 'transaction silently rolled back' },
+    ] as any;
+    const { service } = createService({
+      valid: false,
+      validationMessages: messages,
+    });
+
+    let result: ValidationResults;
+    service.validateSubstance().subscribe(value => result = value);
+
+    expect(result!.valid).toBeFalse();
+    expect(result!.validationMessages).toEqual(messages);
+  });
+
+  function createComponent(validationResponses: Subject<ValidationResults>[]) {
+    const component = Object.create(SubstanceFormComponent.prototype) as SubstanceFormComponent;
+    let responseIndex = 0;
+    (component as any).substanceFormService = {
+      validationMutations: jasmine.createSpy('validationMutations'),
+      validateSubstance: jasmine.createSpy('validateSubstance').and.callFake(
+        () => validationResponses[responseIndex++],
+      ),
+    };
+    (component as any).activatedRoute = { snapshot: { queryParams: {} } };
+    (component as any).loadingService = { setLoading: jasmine.createSpy('setLoading') };
+    component.validationMessages = [{ messageType: 'ERROR', message: 'old error' } as any];
+    component.submissionMessage = 'stale valid message';
+    component.showSubmissionMessages = true;
+    return component;
+  }
+
+  it('clears stale validation state before each backend attempt', () => {
+    const response = new Subject<ValidationResults>();
+    const component = createComponent([response]);
+
+    component.validate();
+
+    expect(component.validationMessages).toBeNull();
+    expect(component.submissionMessage).toBeNull();
+    expect(component.showSubmissionMessages).toBeFalse();
+    expect((component as any).substanceFormService.validateSubstance).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let an older valid response replace newer validation errors', () => {
+    const first = new Subject<ValidationResults>();
+    const second = new Subject<ValidationResults>();
+    const component = createComponent([first, second]);
+
+    component.validate();
+    component.validate();
+    second.next({
+      valid: false,
+      validationMessages: [{ messageType: 'ERROR', message: 'duplicate' } as any],
+    });
+    first.next({ valid: true, validationMessages: [] });
+
+    expect(component.validationResult).toBeFalse();
+    expect(component.validationMessages[0].message).toBe('duplicate');
+    expect(component.submissionMessage).toBeNull();
+  });
+});

--- a/src/app/core/substance-form/substance-form.component.ts
+++ b/src/app/core/substance-form/substance-form.component.ts
@@ -86,6 +86,7 @@ export class SubstanceFormComponent implements OnInit, AfterViewInit, AfterViewC
   submissionMessage: string;
   validationMessages: Array<ValidationMessage>;
   validationResult = true;
+  private validationAttempt = 0;
   private subscriptions: Array<Subscription> = [];
   copy: string;
   private overlayContainer: HTMLElement;
@@ -1054,6 +1055,7 @@ export class SubstanceFormComponent implements OnInit, AfterViewInit, AfterViewC
   }
 
   validate(validationType?: string): void {
+    const validationAttempt = ++this.validationAttempt;
     if (validationType && validationType === 'approval') {
       this.approving = true;
     } else {
@@ -1064,14 +1066,23 @@ export class SubstanceFormComponent implements OnInit, AfterViewInit, AfterViewC
 
     this.isLoading = true;
     this.serverError = false;
+    this.submissionMessage = null;
+    this.validationMessages = null;
+    this.validationResult = null;
+    this.showSubmissionMessages = false;
     this.loadingService.setLoading(true);
     let stagingID = null;
     if (this.activatedRoute.snapshot.queryParams['stagingID']) {
       stagingID = this.activatedRoute.snapshot.queryParams['stagingID'];
     }
     this.substanceFormService.validateSubstance(stagingID).pipe(take(1)).subscribe(results => {
-      this.submissionMessage = null;
-      this.validationMessages = results.validationMessages.filter(
+      if (validationAttempt !== this.validationAttempt) {
+        return;
+      }
+      const validationMessages = Array.isArray(results.validationMessages)
+        ? results.validationMessages
+        : [];
+      this.validationMessages = validationMessages.filter(
         message => message.messageType.toUpperCase() === 'ERROR' || message.messageType.toUpperCase() === 'WARNING' || message.messageType.toUpperCase() === 'NOTICE');
       this.validationResult = results.valid;
       this.showSubmissionMessages = true;
@@ -1084,6 +1095,9 @@ export class SubstanceFormComponent implements OnInit, AfterViewInit, AfterViewC
         this.submissionMessage = 'Are you sure you\'d like to approve this substance?';
       }
     }, error => {
+      if (validationAttempt !== this.validationAttempt) {
+        return;
+      }
       this.addServerError(error);
       this.loadingService.setLoading(false);
       this.isLoading = false;

--- a/src/app/core/substance-form/substance-form.service.ts
+++ b/src/app/core/substance-form/substance-form.service.ts
@@ -2322,4 +2322,3 @@ interface TestSequence {
   subgroups?: Array<any>;
   subunits?: Array<SequenceUnit>;
 }
-


### PR DESCRIPTION
Hi Mitch,

I applied a set of changes to address the isotope loss issue when using Ketcher and JSDraw.

During investigation, I found that the root cause was preexisting and was not introduced by the Angular upgrade. The issue appears to stem from a combination of Ketcher's handling of isotope information and how the frontend processes editor load/update events.

The changes mainly:

* Preserve isotope information during load, validation, save, editor toggle, and reopen flows.
* Prevent programmatic editor loads from being treated as structure edits.
* Restore the previously selected editor (Ketcher/JSDraw) when reopening a substance.
* Fix validation state issues where stale validation results could be reused.
* Ensure existing substances still go through backend validation.

I also evaluated upgrading Ketcher as a potential solution. Unfortunately, the newer version did not resolve the underlying isotope issue and introduced additional compatibility and integration work that would need to be addressed separately. Given the time available before my upcoming vacation, I focused on completing and stabilizing the work already in progress rather than expanding the scope into a larger Ketcher upgrade effort.

I manually tested the main scenarios around isotope preservation, validation, save/reopen flows, and editor switching. The fix appears to resolve the reported issues, but it would benefit from broader testing, especially around structures with more advanced chemistry features.

A few areas should still be improved in a future iteration:

* Fix the existing Karma test configuration so automated tests can run properly.
* Investigate the extra leading `null` appearing in some molfile exports.
* Expand coverage for polymers, S-groups, R-groups, radicals, query structures, and other advanced molfile features.
* Consider adding backend safeguards so editor-specific issues cannot accidentally remove structure metadata in the future.

One implementation detail worth noting is that Ketcher display now uses a limited V3000 conversion for simple isotope-containing structures to avoid isotope loss on the canvas. V2000 remains the canonical format used for storage and export. The V3000 conversion covers the scenarios tested for this issue but is not intended to be a complete chemistry format conversion layer.