### PR TITLE
Fix empty structure editor when starting registration from a zero-hit…

### DIFF
--- a/src/app/core/substance-form/substance-form.component.ts
+++ b/src/app/core/substance-form/substance-form.component.ts
@@ -543,7 +543,9 @@ export class SubstanceFormComponent implements OnInit, AfterViewInit, AfterViewC
     const structure = this.activatedRoute.snapshot.queryParams['importStructure'] || null;
     if (structure) {
       let decode = decodeURIComponent(structure);
-      setTimeout(() => {
+      // Wait until the substance is loaded before importing, otherwise this can
+      // race with loadSubstance() (called async in ngOnInit) and get silently dropped.
+      this.substanceFormService.ready().subscribe(() => {
         this.setStructureFromUrl(decode, 'molfile');
       });
     }


### PR DESCRIPTION
… structure search
The SMILES import in ngAfterViewInit raced against loadSubstance(), which
became async when ngOnInit started awaiting hasSpecificPrivilege() checks.
ngAfterViewInit now fired before the substance object existed, so
importStructure() silently no-op'd and the editor loaded blank.

Wait on substanceFormService.ready() instead of a bare setTimeout so the
import only runs once the substance is actually loaded.